### PR TITLE
Implement logout system

### DIFF
--- a/__tests__/config/environmentConfig.spec.ts
+++ b/__tests__/config/environmentConfig.spec.ts
@@ -45,12 +45,10 @@ describe('Environment environmentConfig', () => {
 
   describe('Check environment configuration', () => {
     it('should be accessible and usable', () => {
-      const {
-        environmentConfig,
-      } = require('../../src/config/environmentConfig');
+      const { environmentConfig } = require('../../src/config/environmentConfig');
       expect(environmentConfig).toBeDefined();
       expect(typeof environmentConfig).toBe('object');
-      expect(Object.keys(environmentConfig).length).toBe(14);
+      expect(Object.keys(environmentConfig).length).toBe(15);
     });
 
     it('should validate and export the configuration object', () => {
@@ -62,7 +60,8 @@ describe('Environment environmentConfig', () => {
         APPINSIGHTS_SECRET_NAME: 'appinsights--connections string',
         ELASTICSEARCH_API: 'https://elasticsearch-api.com',
         WEBDOMAIN: '',
-        KEYBOARD_FILTER_LOCAL_BASE_URL: ''
+        KEYBOARD_FILTER_LOCAL_BASE_URL: '',
+        AUTH0_JWT_ENV: 'test',
       };
       process.env = { ...mockConfig };
 
@@ -83,11 +82,10 @@ describe('Environment environmentConfig', () => {
         classifierApiUrl: Joi.string().allow('').default(''),
         classifierApiKey: Joi.string().allow('').default(''),
         keyboardFiltersBaseUrl: Joi.string().allow('').default(''),
+        auth0JwtEnv: Joi.string().allow('').default(''),
       });
 
-      const {
-        environmentConfig,
-      } = require('../../src/config/environmentConfig');
+      const { environmentConfig } = require('../../src/config/environmentConfig');
 
       const { error, value } = schema.validate(environmentConfig);
 

--- a/__tests__/controllers/web/HomeController.spec.ts
+++ b/__tests__/controllers/web/HomeController.spec.ts
@@ -4,7 +4,6 @@ import { Request, ResponseToolkit } from '@hapi/hapi';
 import { decode } from 'jsonwebtoken';
 import {
   BASE_PATH,
-  jwtCookieName,
   formIds,
   guidedSearchSteps,
   pageTitles,
@@ -14,7 +13,7 @@ import {
 import { HomeController } from '../../../src/controllers/web/HomeController';
 import { getSearchResultsCount } from '../../../src/services/handlers/searchApi';
 import { readQueryParams, upsertQueryParams } from '../../../src/utils/queryStringHelper';
-import { authSchema } from '../../../src/infrastructure/plugins/auth';
+import { authSchema, jwtCookieName } from '../../../src/infrastructure/plugins/auth';
 
 jest.mock('../../../src/infrastructure/plugins/appinsights-logger', () => ({
   info: jest.fn(),

--- a/__tests__/infrastructure/plugins/views.spec.ts
+++ b/__tests__/infrastructure/plugins/views.spec.ts
@@ -1,6 +1,6 @@
 import { environmentConfig } from '../../../src/config/environmentConfig';
 import path from 'path';
-import { BASE_PATH, loginUrl, logoutApiUrl, webRoutePaths } from '../../../src/utils/constants';
+import { BASE_PATH, webRoutePaths } from '../../../src/utils/constants';
 import nunjucks, { Environment } from 'nunjucks';
 import { customHapiViews } from '../../../src/infrastructure/plugins/views';
 
@@ -20,6 +20,8 @@ const {
   termsAndConditions,
   privacyPolicy,
   cookiePolicy,
+  login,
+  logout,
 } = webRoutePaths;
 
 describe('Vision Plugin Configuration', () => {
@@ -70,8 +72,8 @@ describe('Vision Plugin Configuration', () => {
         termsAndConditions: `${BASE_PATH}${termsAndConditions}`,
         privacyPolicy: `${BASE_PATH}${privacyPolicy}`,
         cookiePolicy: `${BASE_PATH}${cookiePolicy}`,
-        logOut: environmentConfig.isLocal ? '' : `${logoutApiUrl}`,
-        logIn: environmentConfig.isLocal ? '' : `${loginUrl}`,
+        logOut: `${BASE_PATH}${logout}`,
+        logIn: environmentConfig.isLocal ? '' : login,
       },
       appInsightsConnectionString: environmentConfig.appInsightsConnectionString,
       gtmId: environmentConfig.gtmId,

--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -312,7 +312,7 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:46463/natural-capital-ecosystem-assessment/accessibility-statement" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33103%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -343,7 +343,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://0.0.0.0:4000/natural-capital-ecosystem-assessment/date-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F0.0.0.0%3A4000%2Fnatural-capital-ecosystem-assessment%2Fdate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -755,7 +755,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Details route template Document details with data Check status code and
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:45579/natural-capital-ecosystem-assessment/search/%7B1234-56789213123-1233-1234%7D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37079%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1283,7 +1283,7 @@ exports[`Details route template Document details with data Check status code and
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         
@@ -1582,7 +1582,7 @@ exports[`Details route template Document details with partial data Check status 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:38701/natural-capital-ecosystem-assessment/search/%7B1234-56789213123-1233-1234%7D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37133%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2397,7 +2397,7 @@ exports[`Details route template Document details with partial data Check status 
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://0.0.0.0:4000/natural-capital-ecosystem-assessment/coordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F0.0.0.0%3A4000%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -580,7 +580,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:36067/natural-capital-ecosystem-assessment/coordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43551%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -600,7 +600,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://0.0.0.0:4000/natural-capital-ecosystem-assessment" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F0.0.0.0%3A4000%2Fnatural-capital-ecosystem-assessment" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -469,7 +469,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:37633/natural-capital-ecosystem-assessment/search?fdy=2000&amp;tdy=2023&amp;jry=gs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42863%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1888,7 +1888,7 @@ exports[`Results block template Guided search journey Search results with empty 
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         
@@ -2185,7 +2185,7 @@ exports[`Results block template Guided search journey Search results with error 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:35587/natural-capital-ecosystem-assessment/search?fdy=2000&amp;tdy=2023&amp;jry=gs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36627%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2909,7 +2909,7 @@ exports[`Results block template Guided search journey Search results with error 
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         
@@ -3206,7 +3206,7 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:37277/natural-capital-ecosystem-assessment/search?q=marine&amp;jry=qs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41061%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -5134,7 +5134,7 @@ exports[`Results block template Quick search journey Search results with data sh
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         
@@ -5431,7 +5431,7 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:35339/natural-capital-ecosystem-assessment/search?q=marine&amp;jry=qs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38721%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -7099,7 +7099,7 @@ exports[`Results block template Quick search journey Search results with empty d
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         
@@ -7396,7 +7396,7 @@ exports[`Results block template Quick search journey Search results with error s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http://127.0.0.1:39797/natural-capital-ecosystem-assessment/search?q=marine&amp;jry=qs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42161%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -8120,7 +8120,7 @@ exports[`Results block template Quick search journey Search results with error s
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.3.0</p>
+          <p>Version: v1.4.0</p>
         </div>
         
         

--- a/__tests__/schema/environmentConfig.schema.spec.ts
+++ b/__tests__/schema/environmentConfig.schema.spec.ts
@@ -17,6 +17,7 @@ describe('Environment Configuration Schema', () => {
       expect(value.classifierApiUrl).toEqual('');
       expect(value.classifierApiKey).toEqual('');
       expect(value.webDomain).toEqual('');
+      expect(value.auth0JwtEnv).toEqual('');
     });
 
     it('should keep provided values for fields if available', () => {
@@ -39,6 +40,7 @@ describe('Environment Configuration Schema', () => {
       expect(value.classifierApiUrl).toEqual('');
       expect(value.classifierApiKey).toEqual('');
       expect(value.webDomain).toEqual('');
+      expect(value.auth0JwtEnv).toEqual('');
     });
   });
 
@@ -59,6 +61,7 @@ describe('Environment Configuration Schema', () => {
         classifierApiKey: 'your-key',
         webDomain: '',
         keyboardFiltersBaseUrl: '',
+        auth0JwtEnv: 'test',
       };
 
       const { error, value } = environmentSchema.validate(validConfig);
@@ -85,9 +88,7 @@ describe('Environment Configuration Schema', () => {
 
       const { error } = environmentSchema.validate(invalidConfig);
       expect(error).toBeDefined();
-      expect(error?.details[0]?.message).toContain(
-        'Provided Environment is not valid',
-      );
+      expect(error?.details[0]?.message).toContain('Provided Environment is not valid');
     });
 
     it('should invalidate a configuration with key vault url as string instead of URL', () => {
@@ -99,9 +100,7 @@ describe('Environment Configuration Schema', () => {
 
       const { error } = environmentSchema.validate(invalidConfig);
       expect(error).toBeDefined();
-      expect(error?.details[0]?.message).toContain(
-        'Azure Key Vault URI must be a valid URL or an empty string',
-      );
+      expect(error?.details[0]?.message).toContain('Azure Key Vault URI must be a valid URL or an empty string');
     });
 
     it('should invalidate a configuration with elasticsearch api as string instead of URL', () => {
@@ -113,9 +112,7 @@ describe('Environment Configuration Schema', () => {
 
       const { error } = environmentSchema.validate(invalidConfig);
       expect(error).toBeDefined();
-      expect(error?.details[0]?.message).toContain(
-        'Elasticsearch API must be a valid URL or an empty string',
-      );
+      expect(error?.details[0]?.message).toContain('Elasticsearch API must be a valid URL or an empty string');
     });
 
     it('should invalidate a configuration with isLocal as string instead of boolea', () => {

--- a/src/config/environmentConfig.ts
+++ b/src/config/environmentConfig.ts
@@ -27,6 +27,7 @@ const config: EnvironmentConfig = {
   elasticSearchPassword: process.env.ES_PASSWORD,
   webDomain: process.env.WEBDOMAIN,
   keyboardFiltersBaseUrl: process.env.KEYBOARD_FILTER_LOCAL_BASE_URL || '',
+  auth0JwtEnv: process.env.AUTH0_JWT_ENV,
 };
 console.log('ENV CONFIG: ', config);
 

--- a/src/controllers/web/HomeController.ts
+++ b/src/controllers/web/HomeController.ts
@@ -2,6 +2,7 @@
 
 import { Request, ResponseObject, ResponseToolkit } from '@hapi/hapi';
 
+import { allowedRedirectHosts, jwtCookieName, jwtCookieOptions } from '../../infrastructure/plugins/auth';
 import { IGuidedSearchStepsMatrix, IStepRouteMatrix } from '../../interfaces/guidedSearch.interface';
 import { ISearchPayload } from '../../interfaces/queryBuilder.interface';
 import { getSearchResultsCount } from '../../services/handlers/searchApi';
@@ -94,6 +95,21 @@ const HomeController = {
     return response.view('screens/home/cookie_policy', {
       pageTitle: pageTitles.cookiePolicy,
     });
+  },
+  logoutHander: (request: Request, response: ResponseToolkit) => {
+    response.unstate(jwtCookieName, jwtCookieOptions);
+
+    let redirectUri = request.query?.redirect_uri;
+    try {
+      // make sure the url is valid and has a hostname that is allowed
+      if (!redirectUri || !allowedRedirectHosts.includes(new URL(redirectUri).hostname)) {
+        redirectUri = BASE_PATH;
+      }
+    } catch {
+      redirectUri = BASE_PATH;
+    }
+
+    return response.redirect(redirectUri);
   },
 };
 

--- a/src/infrastructure/plugins/views.ts
+++ b/src/infrastructure/plugins/views.ts
@@ -6,7 +6,7 @@ import nunjucks from 'nunjucks';
 import dateFilter from 'nunjucks-date-filter';
 
 import { environmentConfig } from '../../config/environmentConfig';
-import { BASE_PATH, loginUrl, logoutApiUrl, webRoutePaths } from '../../utils/constants';
+import { BASE_PATH, webRoutePaths } from '../../utils/constants';
 
 const packageJsonPath = path.join(process.cwd(), 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -24,6 +24,8 @@ const {
   termsAndConditions,
   privacyPolicy,
   cookiePolicy,
+  login,
+  logout,
 } = webRoutePaths;
 
 const customHapiViews = {
@@ -85,10 +87,8 @@ const customHapiViews = {
         termsAndConditions: `${BASE_PATH}${termsAndConditions}`,
         privacyPolicy: `${BASE_PATH}${privacyPolicy}`,
         cookiePolicy: `${BASE_PATH}${cookiePolicy}`,
-        // Logging in/out in development won't work due to the cookie being added manually
-        // so leave the URL blank
-        logIn: environmentConfig.isLocal ? '' : `${loginUrl}`,
-        logOut: environmentConfig.isLocal ? '' : `${logoutApiUrl}`,
+        logOut: `${BASE_PATH}${logout}`,
+        logIn: environmentConfig.isLocal ? '' : login, // dont want the base path on this URL as it should navigate to the core platform instead
       },
       appInsightsConnectionString: environmentConfig.appInsightsConnectionString,
       gtmId: environmentConfig.gtmId,

--- a/src/interfaces/environmentConfig.interface.ts
+++ b/src/interfaces/environmentConfig.interface.ts
@@ -13,4 +13,5 @@ export interface EnvironmentConfig {
   elasticSearchPassword?: string;
   webDomain?: string;
   keyboardFiltersBaseUrl?: string | undefined;
+  auth0JwtEnv?: string;
 }

--- a/src/routes/web/home.ts
+++ b/src/routes/web/home.ts
@@ -45,6 +45,11 @@ const homeRoutes = [
     path: webRoutePaths.cookiePolicy,
     handler: HomeController.cookiePolicyHandler,
   },
+  {
+    method: 'GET',
+    path: webRoutePaths.logout,
+    handler: HomeController.logoutHander,
+  },
 ];
 
 export { homeRoutes };

--- a/src/schema/environmentConfig.schema.ts
+++ b/src/schema/environmentConfig.schema.ts
@@ -55,4 +55,7 @@ export const environmentSchema: Joi.ObjectSchema = Joi.object({
   keyboardFiltersBaseUrl: Joi.string().allow('').default('').messages({
     'string.base': 'The keyboard filters base url must be a string.',
   }),
+  auth0JwtEnv: Joi.string().allow('').default('').messages({
+    'string.base': 'The auth0 JWT environment must be a string.',
+  }),
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,6 +24,8 @@ export const webRoutePaths = {
   mdc: `/mdc/mdc.xsd`,
   mdcClassifiers: `/mdc/classifiers.xsd`,
   mdcIdentifiers: `/mdc/identifiers.xsd`,
+  logout: `/logout`,
+  login: `/login`,
 };
 
 export const elasticSearchAPIPaths = {
@@ -264,7 +266,4 @@ export const defaultFilters: ISearchFiltersProcessed = {
   retiredAndArchived: false,
 };
 
-export const logoutApiUrl = `/api/logout`;
-export const loginUrl = `/login`;
-
-export const jwtCookieName = 'auth0-jwt-live';
+export const jwtCookiePrefix = 'auth0-jwt-';

--- a/src/views/layout/default.njk
+++ b/src/views/layout/default.njk
@@ -76,7 +76,7 @@
     <div class="govuk-grid-col login">
       {% if user %}
         <p class="govuk-body-m">Welcome, {{ user.email }}</p>
-        <a href="{{routes.logOut}}" class="govuk-link govuk-body-m">Logout</a>
+        <a href="{{routes.logOut}}?redirect_uri={{redirectUri}}" class="govuk-link govuk-body-m">Logout</a>
       {% else %}
         <p class="govuk-body-m">Welcome, Guest</p>
         <a href="{{routes.logIn}}{% if not routes.logIn == "" %}?redirect_uri={{redirectUri}}{% endif %}" class="govuk-link govuk-body-m">Login</a>


### PR DESCRIPTION
This PR implements a logout system on our side, so AGM do not need to modify the logout system in DSP.
A new `/logout` endpoint has bee added and the logout button makes a `GET` request to this, including a `redirect_uri` query parameter which will redirect the user back to the page they logged out from. It removes the cookie from the browser so they appear logged out.
The value of `redirect_uri` is validated against allowed hostnames for security, although less necessary for logging out.

The tests that broke due to the changes have also been updated. 
