### PR TITLE
Date filter validation and clear/apply filters buttons.

### DIFF
--- a/__tests__/data/documentDetailsResponse.ts
+++ b/__tests__/data/documentDetailsResponse.ts
@@ -283,6 +283,7 @@ const formattedDetailsResponse: ISearchResults = {
      },
     },
   ],
+  hasSpatialData: false,
 };
 
 const detailsSuccessAPIFullData = {
@@ -955,6 +956,7 @@ const formattedDetailsFullResponse: ISearchResults = {
         },
      },
   ],
+  hasSpatialData: false,
 };
 
 export {

--- a/__tests__/data/searchResultsResponse.ts
+++ b/__tests__/data/searchResultsResponse.ts
@@ -30,11 +30,13 @@ const searchResultsWithData: ISearchResults = {
       resource_locators : 'Download from Seabed Mapping Service (https://seabed.admiralty.co.uk)'
     },
   ],
+  hasSpatialData: false,
 };
 
 const searchResultsWithEmptyData = {
   total: 0,
   items: [],
+  hasSpatialData: false,
 };
 
 export { searchResultsWithData, searchResultsWithEmptyData };

--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -32,129 +32,96 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -178,38 +145,44 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -227,8 +200,7 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
   
       <div class="govuk-width-container">
         
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -240,7 +212,7 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
 </div>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
@@ -268,53 +240,55 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -331,25 +305,21 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -32,129 +32,96 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -178,38 +145,44 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -217,7 +190,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42137%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41043%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -228,8 +201,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -241,17 +213,12 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
 </div>
 
 
-  <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+  <div class="govuk-breadcrumbs">
   <ol class="govuk-breadcrumbs__list">
 
   
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment"
-    
-        
-      
-    
-   data-do-storage-reset="">Home</a>
+      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment" data-do-storage-reset="">Home</a>
     </li>
   
 
@@ -260,10 +227,10 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
   
 
   </ol>
-</nav>
+</div>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   <article class="govuk-grid-row" role="article">
     <article class="govuk-grid-column-full ncea-static-page">
@@ -299,53 +266,55 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -362,25 +331,21 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -32,129 +32,96 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -178,38 +145,44 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -228,8 +201,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -246,7 +218,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 <a href="#" class="govuk-back-link back-link-date">Back</a>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   
 <div class="govuk-grid-row">
@@ -271,17 +243,15 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
     </h2>
     <div class="govuk-error-summary__body">
       
+      <ul class="govuk-list govuk-error-summary__list">
       
-        <ul class="govuk-list govuk-error-summary__list">
+        <li>
         
-          <li>
-          
-            You must make a selection or click skip to continue
-          
-          </li>
+          You must make a selection or click skip to continue
         
-        </ul>
+        </li>
       
+      </ul>
     </div>
   </div>
 </div>
@@ -306,7 +276,6 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 
 
 
-
   
 <div class="govuk-form-group">
 
@@ -326,7 +295,6 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
   
     <div class="govuk-date-input" id="from-date">
       
-      
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="day">
@@ -334,40 +302,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="from-date-day" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="fdd">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="from-date-day" type="text" inputmode="numeric" altName="fdd">
         
         </div>
       </div>
-      
+    
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="month">
@@ -375,40 +314,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="from-date-month" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="fdm">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="from-date-month" type="text" inputmode="numeric" altName="fdm">
         
         </div>
       </div>
-      
+    
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="year">
@@ -416,41 +326,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="from-date-year" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="fdy">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="from-date-year" type="text" inputmode="numeric" altName="fdy">
         
         </div>
       </div>
-      
-      
+    
     </div>
   
   </fieldset>
@@ -462,7 +342,6 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 <h2 class="govuk-heading-m">
   To
 </h2>
-
 
 
 
@@ -486,7 +365,6 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
   
     <div class="govuk-date-input" id="to-date">
       
-      
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="day">
@@ -494,40 +372,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="to-date-day" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="tdd">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="day" name="to-date-day" type="text" inputmode="numeric" altName="tdd">
         
         </div>
       </div>
-      
+    
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="month">
@@ -535,40 +384,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="to-date-month" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="tdm">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="month" name="to-date-month" type="text" inputmode="numeric" altName="tdm">
         
         </div>
       </div>
-      
+    
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label class="govuk-label govuk-date-input__label" for="year">
@@ -576,41 +396,11 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           </label>
         
         
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="to-date-year" type="text" inputmode="numeric"
-            
-                
-              
-            
-           altName="tdy">
+          <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="year" name="to-date-year" type="text" inputmode="numeric" altName="tdy">
         
         </div>
       </div>
-      
-      
+    
     </div>
   
   </fieldset>
@@ -622,39 +412,28 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="today-date" name="today-date" type="checkbox" value=""
-    
+          
         
-      
-    
-        
-      
-    
-   class="defra-checkboxes__input" altName="tdcheck">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="today-date">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="today-date" name="today-date" type="checkbox" value="" class="defra-checkboxes__input" altName="tdcheck">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="today-date">
         Today&#39;s date
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -671,12 +450,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
     
   
 
-<a href="/coordinate-search?jry=gs&amp;cnt=10" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-skip="">
+<a href="/coordinate-search?jry=gs&amp;cnt=10" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" data-do-storage-skip="">
   Skip
 </a>
 
@@ -687,15 +461,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0" data-module="govuk-button"
-    
-        
-      
-    
-        
-      
-    
-   data-to-disable="" data-next-question="">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0" data-module="govuk-button" data-to-disable="" data-next-question="">
   Next
 </button>
 
@@ -711,53 +477,55 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -774,25 +542,21 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -35,129 +35,96 @@ exports[`Details route template Document details with data Check status code and
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -181,38 +148,44 @@ exports[`Details route template Document details with data Check status code and
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -220,7 +193,7 @@ exports[`Details route template Document details with data Check status code and
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38069%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38945%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -231,8 +204,7 @@ exports[`Details route template Document details with data Check status code and
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -251,17 +223,12 @@ exports[`Details route template Document details with data Check status code and
     
   
 
-  <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+  <div class="govuk-breadcrumbs">
   <ol class="govuk-breadcrumbs__list">
 
   
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment"
-    
-        
-      
-    
-   data-do-storage-reset="">Home</a>
+      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment" data-do-storage-reset="">Home</a>
     </li>
   
 
@@ -276,10 +243,10 @@ exports[`Details route template Document details with data Check status code and
   
 
   </ol>
-</nav>
+</div>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     
       
@@ -325,12 +292,7 @@ exports[`Details route template Document details with data Check status code and
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-4 go-to-resource govuk-button--start" data-module="govuk-button"
-    
-        
-      
-    
-   onclick="openDataModal(&#39;United Kingdom Hydrographic Office&#39;, &#39;https://seabed.admiralty.co.uk&#39;)">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-4 go-to-resource govuk-button--start" data-module="govuk-button" onclick="openDataModal(&#39;United Kingdom Hydrographic Office&#39;, &#39;https://seabed.admiralty.co.uk&#39;)">
   Go to resource
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
@@ -343,842 +305,880 @@ exports[`Details route template Document details with data Check status code and
   <h2 class="govuk-tabs__title">
     Contents
   </h2>
-
+  
   <ul class="govuk-tabs__list">
     
-          <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab" href="#general"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - General&quot;)">
-        General
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#general" onclick="changeTitle(&quot;NCEA Catalogue Detail - General&quot;)">
+            General
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#access"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Access&quot;)">
-        Access
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#access" onclick="changeTitle(&quot;NCEA Catalogue Detail - Access&quot;)">
+            Access
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#natural"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Natural Capital&quot;)">
-        Natural capital
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#natural" onclick="changeTitle(&quot;NCEA Catalogue Detail - Natural Capital&quot;)">
+            Natural capital
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#quality"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Quality&quot;)">
-        Quality
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#quality" onclick="changeTitle(&quot;NCEA Catalogue Detail - Quality&quot;)">
+            Quality
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#geography"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Geography&quot;)">
-        Geography
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#geography" onclick="changeTitle(&quot;NCEA Catalogue Detail - Geography&quot;)">
+            Geography
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#license"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - License&quot;)">
-        License
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#license" onclick="changeTitle(&quot;NCEA Catalogue Detail - License&quot;)">
+            License
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#governance"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Governance&quot;)">
-        Governance
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#governance" onclick="changeTitle(&quot;NCEA Catalogue Detail - Governance&quot;)">
+            Governance
+          </a>
+        </li>
       
     
   </ul>
   
+  
+    
+      
       <div class="govuk-tabs__panel" id="general">
-  
-    <div class='tab-content-container'>
         
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Abstract</h2>
-              
-                <span class='tab-content-value'>
-                  This processed bathymetric data set has been derived from an Echosounder - multibeam survey. The source data was collected, validated and processed for the purpose of Safety Of Life At Sea (SOLAS). The data set must not be used for navigation or to create products that could be used for navigation.
-                </span>
-              
-            </div>
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Abstract</h2>
           
+            <span class='tab-content-value'>
+              This processed bathymetric data set has been derived from an Echosounder - multibeam survey. The source data was collected, validated and processed for the purpose of Safety Of Life At Sea (SOLAS). The data set must not be used for navigation or to create products that could be used for navigation.
+            </span>
           
-        
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Study periods</h2>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Study periods</h2>
-              
-                <span class='tab-content-value'>
-                  24 May 2019 to 31 July 2019
-                </span>
-              
-            </div>
+            <span class='tab-content-value'>
+              24 May 2019 to 31 July 2019
+            </span>
           
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Topic categories</h2>
           
-        
+            <span class='tab-content-value'>
+              Elevation
+            </span>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Topic categories</h2>
-              
-                <span class='tab-content-value'>
-                  Elevation
-                </span>
-              
-            </div>
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Keywords</h2>
           
+            <span class='tab-content-value'>
+              Elevation, Marine Environmental Data and Information Network, Bathymetry and Elevation
+            </span>
           
-        
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource languages</h2>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Keywords</h2>
-              
-                <span class='tab-content-value'>
-                  Elevation, Marine Environmental Data and Information Network, Bathymetry and Elevation
-                </span>
-              
-            </div>
+            <span class='tab-content-value'>
+              ENG
+            </span>
           
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource languages</h2>
-              
-                <span class='tab-content-value'>
-                  ENG
-                </span>
-              
-            </div>
-          
-          
+        </div>
+      
+      
+    
+  </div>
+
         
       </div>
-  
-  </div>
     
   
+    
+      
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="access">
-  
-    <div class='tab-content-container'>
         
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>File Identifier</h2>
-              
-                <span class='tab-content-value'>
-                  fb8dca0f-7425-4f50-86a1-c4673b1aef88
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource Identifier</h2>
-              
-                <span class='tab-content-value'>
-                  https://seabed.admiralty.co.ukfb8dca0f-7425-4f50-86a1-c4673b1aef88
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Coupled resources</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+  <div class='tab-content-container'>
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>File Identifier</h2>
           
+            <span class='tab-content-value'>
+              fb8dca0f-7425-4f50-86a1-c4673b1aef88
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource type</h2>
-              
-                <span class='tab-content-value'>
-                  Dataset
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource locators</h2>
-              
-                <span class='tab-content-value'>
-                  <p>Download from Seabed Mapping Service (<a class="govuk-link" href="https://seabed.admiralty.co.uk" target="_blank">https://seabed.admiralty.co.uk</a>)</p>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Contact information</h2>
-              
-                <span class='tab-content-value'>
-                  undefined :- customerservices@ukho.gov.uk, <br />United Kingdom Hydrographic Office :- customerservices@ukho.gov.uk, <br />undefined :- customerservices@ukho.gov.uk, <br />undefined :- customerservices@ukho.gov.uk, <br />United Kingdom Hydrographic Office :- customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Catalouge entry</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource Identifier</h2>
           
+            <span class='tab-content-value'>
+              https://seabed.admiralty.co.ukfb8dca0f-7425-4f50-86a1-c4673b1aef88
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>NCEA catalogue number</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Coupled resources</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Parent identifier</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource type</h2>
           
+            <span class='tab-content-value'>
+              Dataset
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata standard</h2>
-              
-                <span class='tab-content-value'>
-                  MEDIN
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Project number</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource locators</h2>
           
+            <span class='tab-content-value'>
+              <p>Download from Seabed Mapping Service (<a class="govuk-link" href="https://seabed.admiralty.co.uk" target="_blank">https://seabed.admiralty.co.uk</a>)</p>
+            </span>
           
-        
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Contact information</h2>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata language</h2>
-              
-                <span class='tab-content-value'>
-                  ENG
-                </span>
-              
-            </div>
+            <span class='tab-content-value'>
+              undefined :- customerservices@ukho.gov.uk, <br />United Kingdom Hydrographic Office :- customerservices@ukho.gov.uk, <br />undefined :- customerservices@ukho.gov.uk, <br />undefined :- customerservices@ukho.gov.uk, <br />United Kingdom Hydrographic Office :- customerservices@ukho.gov.uk
+            </span>
           
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Catalouge entry</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>NCEA catalogue number</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Parent identifier</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata standard</h2>
+          
+            <span class='tab-content-value'>
+              MEDIN
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Project number</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata language</h2>
+          
+            <span class='tab-content-value'>
+              ENG
+            </span>
+          
+        </div>
+      
+      
+    
+  </div>
+
         
       </div>
-  
-  </div>
     
   
+    
+      
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="natural">
+        
+          
+
+
+
+
+
   
-    <h1 class="quick_search-container__heading-m">Natural capital classification</h1>
-    
-    
-      <p class="ncea-static-page__content-item govuk-!-margin-top-4"">Natural capital records are classified by themes and categories which indicate whether the record relates to natural capital assets (such as habitats and species), the ecosystem services they deliver, the pressures that act on them and/or their value.</p>
-    
-     
-      <p class="search-result__heading govuk-!-margin-top-4">This record is not classifiable within the current natural capital vocabulary.</p>
   
-  </div>
     
-  
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="quality">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of publication</h2>
-              
-                <span class='tab-content-value'>
-                  23 March 2022
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of creation</h2>
-              
-                <span class='tab-content-value'>
-                  23 March 2022
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of last revision</h2>
-              
-                <span class='tab-content-value'>
-                  23 March 2022
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata date</h2>
-              
-                <span class='tab-content-value'>
-                  16 January 2024
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Lineage</h2>
-              
-                <span class='tab-content-value'>
-                  This data set has been derived from an Echosounder - multibeam survey which was collected for the purpose of Safety of navigation, which was collected against S-44 survey specification (of the time). The survey has been validated and processed by the UKHO.
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conformity</h2>
-              
-                <span class='tab-content-value'>
-                  <table class="details-table">
-                          <thead>
-                            <tr>
-                              <th width="60%">Specification</th>
-                              <th width="10%">Degree</th>
-                              <th>Explanation</th>
-                            </tr>
-                          </thead><tbody><tr>
-                          <td>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</td>
-                          <td>false</td>
-                          <td>inapplicable</td>
-                        </tr></tbody></table>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Additional information</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="geography">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial data service</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
     
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial representation service</h2>
-              
-                <span class='tab-content-value'>
-                  Grid
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial referencing system</h2>
-              
-                <span class='tab-content-value'>
-                  WGS 84
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Geographic locations</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Geographic boundary</h2>
-              
-                <span class='tab-content-value'>
-                  <p>West bounding longitude: <span id="west">-15.320435</span></p><p>East bounding longitude: <span id="east">-6.970825</span></p><p>North bounding latitude: <span id="north">50.180526</span></p><p>South bounding latitude: <span id="south">47.912775</span></p>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-          
-            <div id="coordinate-map" class="detail-map" style="height: 335px;"></div>
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Vertical extent<br /><span>(Meters above sea level)</span></h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial resolution</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="license">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Limitations on public access -<br /> Access constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
     
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Limitations on public access -<br /> Other constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conditions for access and use -<br /> Use constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conditions for access and use -<br /> Other constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Distribution formats</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Frequency of update</h2>
-              
-                <span class='tab-content-value'>
-                  Not planned
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Character encoding</h2>
-              
-                <span class='tab-content-value'>
-                  utf8
-                </span>
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="governance">
+    
   
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Role</h2>
-              
-                <span class='tab-content-value'>
-                  owner
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Email</h2>
-              
-                <span class='tab-content-value'>
-                  customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
-              
-                <span class='tab-content-value'>
-                  <div class="govuk-section-break--visible"></div>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Role</h2>
-              
-                <span class='tab-content-value'>
-                  pointOfContact
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Organization name</h2>
-              
-                <span class='tab-content-value'>
-                  United Kingdom Hydrographic Office
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Email</h2>
-              
-                <span class='tab-content-value'>
-                  customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
-              
-                <span class='tab-content-value'>
-                  <div class="govuk-section-break--visible"></div>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Role</h2>
-              
-                <span class='tab-content-value'>
-                  custodian
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Email</h2>
-              
-                <span class='tab-content-value'>
-                  customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
-              
-                <span class='tab-content-value'>
-                  <div class="govuk-section-break--visible"></div>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Role</h2>
-              
-                <span class='tab-content-value'>
-                  distributor
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Email</h2>
-              
-                <span class='tab-content-value'>
-                  customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
-              
-                <span class='tab-content-value'>
-                  <div class="govuk-section-break--visible"></div>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Role</h2>
-              
-                <span class='tab-content-value'>
-                  originator
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Organization name</h2>
-              
-                <span class='tab-content-value'>
-                  United Kingdom Hydrographic Office
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Email</h2>
-              
-                <span class='tab-content-value'>
-                  customerservices@ukho.gov.uk
-                </span>
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+    
+      
     
   
 
+
+
+  <h1 class="quick_search-container__heading-m">Natural capital classification</h1>
+
+
+  <p class="ncea-static-page__content-item govuk-!-margin-top-4"">Natural capital records are classified by themes and categories which indicate whether the record relates to natural capital assets (such as habitats and species), the ecosystem services they deliver, the pressures that act on them and/or their value.</p>
+
+ 
+  <p class="search-result__heading govuk-!-margin-top-4">This record is not classifiable within the current natural capital vocabulary.</p>
+
+
+
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="quality">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of publication</h2>
+          
+            <span class='tab-content-value'>
+              23 March 2022
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of creation</h2>
+          
+            <span class='tab-content-value'>
+              23 March 2022
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of last revision</h2>
+          
+            <span class='tab-content-value'>
+              23 March 2022
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata date</h2>
+          
+            <span class='tab-content-value'>
+              16 January 2024
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Lineage</h2>
+          
+            <span class='tab-content-value'>
+              This data set has been derived from an Echosounder - multibeam survey which was collected for the purpose of Safety of navigation, which was collected against S-44 survey specification (of the time). The survey has been validated and processed by the UKHO.
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conformity</h2>
+          
+            <span class='tab-content-value'>
+              <table class="details-table">
+                      <thead>
+                        <tr>
+                          <th width="60%">Specification</th>
+                          <th width="10%">Degree</th>
+                          <th>Explanation</th>
+                        </tr>
+                      </thead><tbody><tr>
+                      <td>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</td>
+                      <td>false</td>
+                      <td>inapplicable</td>
+                    </tr></tbody></table>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Additional information</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="geography">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial data service</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial representation service</h2>
+          
+            <span class='tab-content-value'>
+              Grid
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial referencing system</h2>
+          
+            <span class='tab-content-value'>
+              WGS 84
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Geographic locations</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Geographic boundary</h2>
+          
+            <span class='tab-content-value'>
+              <p>West bounding longitude: <span id="west">-15.320435</span></p><p>East bounding longitude: <span id="east">-6.970825</span></p><p>North bounding latitude: <span id="north">50.180526</span></p><p>South bounding latitude: <span id="south">47.912775</span></p>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+      
+        <div id="coordinate-map" class="detail-map" style="height: 335px;"></div>
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Vertical extent<br /><span>(Meters above sea level)</span></h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial resolution</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="license">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Limitations on public access -<br /> Access constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Limitations on public access -<br /> Other constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conditions for access and use -<br /> Use constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conditions for access and use -<br /> Other constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Distribution formats</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Frequency of update</h2>
+          
+            <span class='tab-content-value'>
+              Not planned
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Character encoding</h2>
+          
+            <span class='tab-content-value'>
+              utf8
+            </span>
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="governance">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Role</h2>
+          
+            <span class='tab-content-value'>
+              owner
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Email</h2>
+          
+            <span class='tab-content-value'>
+              customerservices@ukho.gov.uk
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
+          
+            <span class='tab-content-value'>
+              <div class="govuk-section-break--visible"></div>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Role</h2>
+          
+            <span class='tab-content-value'>
+              pointOfContact
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Organization name</h2>
+          
+            <span class='tab-content-value'>
+              United Kingdom Hydrographic Office
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Email</h2>
+          
+            <span class='tab-content-value'>
+              customerservices@ukho.gov.uk
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
+          
+            <span class='tab-content-value'>
+              <div class="govuk-section-break--visible"></div>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Role</h2>
+          
+            <span class='tab-content-value'>
+              custodian
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Email</h2>
+          
+            <span class='tab-content-value'>
+              customerservices@ukho.gov.uk
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
+          
+            <span class='tab-content-value'>
+              <div class="govuk-section-break--visible"></div>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Role</h2>
+          
+            <span class='tab-content-value'>
+              distributor
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Email</h2>
+          
+            <span class='tab-content-value'>
+              customerservices@ukho.gov.uk
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'><div class="govuk-section-break--visible"></div></h2>
+          
+            <span class='tab-content-value'>
+              <div class="govuk-section-break--visible"></div>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Role</h2>
+          
+            <span class='tab-content-value'>
+              originator
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Organization name</h2>
+          
+            <span class='tab-content-value'>
+              United Kingdom Hydrographic Office
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Email</h2>
+          
+            <span class='tab-content-value'>
+              customerservices@ukho.gov.uk
+            </span>
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
 </div>
 
 
@@ -1199,12 +1199,7 @@ exports[`Details route template Document details with data Check status code and
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   onclick="closeDataModal()">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" onclick="closeDataModal()">
   Cancel
 </button>
 
@@ -1215,15 +1210,7 @@ exports[`Details route template Document details with data Check status code and
     
   
 
-<a href="#" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-        
-      
-    
-   onclick="closeDataModal()" target="_blank" id="resource-locator-link">
+<a href="#" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button" onclick="closeDataModal()" target="_blank" id="resource-locator-link">
   Open site
 </a>
 
@@ -1239,53 +1226,55 @@ exports[`Details route template Document details with data Check status code and
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -1302,25 +1291,21 @@ exports[`Details route template Document details with data Check status code and
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>
@@ -1397,129 +1382,96 @@ exports[`Details route template Document details with partial data Check status 
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -1543,38 +1495,44 @@ exports[`Details route template Document details with partial data Check status 
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -1582,7 +1540,7 @@ exports[`Details route template Document details with partial data Check status 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46355%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45721%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1593,8 +1551,7 @@ exports[`Details route template Document details with partial data Check status 
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -1613,17 +1570,12 @@ exports[`Details route template Document details with partial data Check status 
     
   
 
-  <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+  <div class="govuk-breadcrumbs">
   <ol class="govuk-breadcrumbs__list">
 
   
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment"
-    
-        
-      
-    
-   data-do-storage-reset="">Home</a>
+      <a class="govuk-breadcrumbs__link" href="/natural-capital-ecosystem-assessment" data-do-storage-reset="">Home</a>
     </li>
   
 
@@ -1638,10 +1590,10 @@ exports[`Details route template Document details with partial data Check status 
   
 
   </ol>
-</nav>
+</div>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     
       
@@ -1675,12 +1627,7 @@ exports[`Details route template Document details with partial data Check status 
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-4 go-to-resource govuk-button--start" data-module="govuk-button"
-    
-        
-      
-    
-   disabled="true">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-4 go-to-resource govuk-button--start" data-module="govuk-button" disabled="true">
   Go to resource
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
@@ -1696,650 +1643,688 @@ exports[`Details route template Document details with partial data Check status 
   <h2 class="govuk-tabs__title">
     Contents
   </h2>
-
+  
   <ul class="govuk-tabs__list">
     
-          <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab" href="#general"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - General&quot;)">
-        General
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#general" onclick="changeTitle(&quot;NCEA Catalogue Detail - General&quot;)">
+            General
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#access"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Access&quot;)">
-        Access
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#access" onclick="changeTitle(&quot;NCEA Catalogue Detail - Access&quot;)">
+            Access
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#natural"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Natural Capital&quot;)">
-        Natural capital
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#natural" onclick="changeTitle(&quot;NCEA Catalogue Detail - Natural Capital&quot;)">
+            Natural capital
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#quality"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Quality&quot;)">
-        Quality
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#quality" onclick="changeTitle(&quot;NCEA Catalogue Detail - Quality&quot;)">
+            Quality
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#geography"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Geography&quot;)">
-        Geography
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#geography" onclick="changeTitle(&quot;NCEA Catalogue Detail - Geography&quot;)">
+            Geography
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#license"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - License&quot;)">
-        License
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#license" onclick="changeTitle(&quot;NCEA Catalogue Detail - License&quot;)">
+            License
+          </a>
+        </li>
       
     
-          <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#governance"
+      
         
-            
-          
-        
-       onclick="changeTitle(&quot;NCEA Catalogue Detail - Governance&quot;)">
-        Governance
-      </a>
-    </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#governance" onclick="changeTitle(&quot;NCEA Catalogue Detail - Governance&quot;)">
+            Governance
+          </a>
+        </li>
       
     
   </ul>
   
+  
+    
+      
       <div class="govuk-tabs__panel" id="general">
-  
-    <div class='tab-content-container'>
         
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Abstract</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+  <div class='tab-content-container'>
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Abstract</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Study periods</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Study periods</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Topic categories</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Topic categories</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Keywords</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Keywords</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource languages</h2>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource languages</h2>
-              
-                <span class='tab-content-value'>
-                  ENG
-                </span>
-              
-            </div>
+            <span class='tab-content-value'>
+              ENG
+            </span>
           
-          
+        </div>
+      
+      
+    
+  </div>
+
         
       </div>
-  
-  </div>
     
   
+    
+      
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="access">
-  
-    <div class='tab-content-container'>
         
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>File Identifier</h2>
-              
-                <span class='tab-content-value'>
-                  3c080cb6-2ed9-43e7-9323-9ce42b05b9a2
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource Identifier</h2>
-              
-                <span class='tab-content-value'>
-                  3c080cb6-2ed9-43e7-9323-9ce42b05b9a2
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Coupled resources</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+  <div class='tab-content-container'>
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>File Identifier</h2>
           
+            <span class='tab-content-value'>
+              3c080cb6-2ed9-43e7-9323-9ce42b05b9a2
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource type</h2>
-              
-                <span class='tab-content-value'>
-                  Dataset
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Resource locators</h2>
-              
-                <span class='tab-content-value'>
-                  <p>Download from Seabed Mapping Service (<a class="govuk-link" href="https://seabed.admiralty.co.uk" target="_blank">https://seabed.admiralty.co.uk</a>)</p>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Contact information</h2>
-              
-                <span class='tab-content-value'>
-                  , <br />
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Catalouge entry</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource Identifier</h2>
           
+            <span class='tab-content-value'>
+              3c080cb6-2ed9-43e7-9323-9ce42b05b9a2
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>NCEA catalogue number</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Coupled resources</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Parent identifier</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource type</h2>
           
+            <span class='tab-content-value'>
+              Dataset
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata standard</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Resource locators</h2>
           
+            <span class='tab-content-value'>
+              <p>Download from Seabed Mapping Service (<a class="govuk-link" href="https://seabed.admiralty.co.uk" target="_blank">https://seabed.admiralty.co.uk</a>)</p>
+            </span>
           
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Project number</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
+        </div>
+      
+      
     
-              
-            </div>
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Contact information</h2>
           
+            <span class='tab-content-value'>
+              , <br />
+            </span>
           
-        
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Catalouge entry</h2>
           
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata language</h2>
-              
-                <span class='tab-content-value'>
-                  ENG
-                </span>
-              
-            </div>
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
           
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>NCEA catalogue number</h2>
           
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Parent identifier</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata standard</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Project number</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata language</h2>
+          
+            <span class='tab-content-value'>
+              ENG
+            </span>
+          
+        </div>
+      
+      
+    
+  </div>
+
         
       </div>
-  
-  </div>
     
   
+    
+      
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="natural">
+        
+          
+
+
+
+
+
   
-    <h1 class="quick_search-container__heading-m">Natural capital classification</h1>
-    
-    
-      <p class="ncea-static-page__content-item govuk-!-margin-top-4"">Natural capital records are classified by themes and categories which indicate whether the record relates to natural capital assets (such as habitats and species), the ecosystem services they deliver, the pressures that act on them and/or their value.</p>
-    
-     
-      <p class="search-result__heading govuk-!-margin-top-4">This record is not classifiable within the current natural capital vocabulary.</p>
   
-  </div>
     
-  
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="quality">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of publication</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of creation</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Date of last revision</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Metadata date</h2>
-              
-                <span class='tab-content-value'>
-                  26 January 2010
-                </span>
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Lineage</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conformity</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Additional information</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="geography">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial data service</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
     
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial representation service</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial referencing system</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Geographic locations</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Geographic boundary</h2>
-              
-                <span class='tab-content-value'>
-                  <p>West bounding longitude: <span id="west"></span></p><p>East bounding longitude: <span id="east"></span></p><p>North bounding latitude: <span id="north"></span></p><p>South bounding latitude: <span id="south"></span></p>
-                </span>
-              
-            </div>
-          
-          
-        
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Vertical extent<br /><span>(Meters above sea level)</span></h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Spatial resolution</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="license">
-  
-    <div class='tab-content-container'>
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Limitations on public access -<br /> Access constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
     
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Limitations on public access -<br /> Other constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conditions for access and use -<br /> Use constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Conditions for access and use -<br /> Other constraints</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Distribution formats</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Frequency of update</h2>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
-      Unavailable
-    </strong>
-    
-              
-            </div>
-          
-          
-        
-          
-            <div class='tab-content-row'>
-              <h2 class='tab-content-label'>Character encoding</h2>
-              
-                <span class='tab-content-value'>
-                  utf8
-                </span>
-              
-            </div>
-          
-          
-        
-      </div>
-  
-  </div>
+      
     
   
-      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="governance">
+    
   
-    <div class='tab-content-container'>
-        
-      </div>
-  
-  </div>
+    
+      
     
   
 
+
+
+  <h1 class="quick_search-container__heading-m">Natural capital classification</h1>
+
+
+  <p class="ncea-static-page__content-item govuk-!-margin-top-4"">Natural capital records are classified by themes and categories which indicate whether the record relates to natural capital assets (such as habitats and species), the ecosystem services they deliver, the pressures that act on them and/or their value.</p>
+
+ 
+  <p class="search-result__heading govuk-!-margin-top-4">This record is not classifiable within the current natural capital vocabulary.</p>
+
+
+
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="quality">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of publication</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of creation</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Date of last revision</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Metadata date</h2>
+          
+            <span class='tab-content-value'>
+              26 January 2010
+            </span>
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Lineage</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conformity</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Additional information</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="geography">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial data service</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial representation service</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial referencing system</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Geographic locations</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Geographic boundary</h2>
+          
+            <span class='tab-content-value'>
+              <p>West bounding longitude: <span id="west"></span></p><p>East bounding longitude: <span id="east"></span></p><p>North bounding latitude: <span id="north"></span></p><p>South bounding latitude: <span id="south"></span></p>
+            </span>
+          
+        </div>
+      
+      
+    
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Vertical extent<br /><span>(Meters above sea level)</span></h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Spatial resolution</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="license">
+        
+          
+  <div class='tab-content-container'>
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Limitations on public access -<br /> Access constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Limitations on public access -<br /> Other constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conditions for access and use -<br /> Use constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Conditions for access and use -<br /> Other constraints</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Distribution formats</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Frequency of update</h2>
+          
+            <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+  Unavailable
+</strong>
+
+          
+        </div>
+      
+      
+    
+      
+        <div class='tab-content-row'>
+          <h2 class='tab-content-label'>Character encoding</h2>
+          
+            <span class='tab-content-value'>
+              utf8
+            </span>
+          
+        </div>
+      
+      
+    
+  </div>
+
+        
+      </div>
+    
+  
+    
+      
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="governance">
+        
+          
+  <div class='tab-content-container'>
+    
+  </div>
+
+        
+      </div>
+    
+  
 </div>
 
 
@@ -2353,53 +2338,55 @@ exports[`Details route template Document details with partial data Check status 
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -2416,25 +2403,21 @@ exports[`Details route template Document details with partial data Check status 
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -35,129 +35,96 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -181,38 +148,44 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -231,8 +204,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -249,7 +221,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
 <a href="/date-search" class="govuk-back-link">Back</a>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   
 <div class="govuk-grid-row">
@@ -281,7 +253,6 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
         <div class="geography-fields__container">
           <div class="geography-fields__field">
 
-
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="north">
     North
@@ -294,41 +265,11 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="north" name="north" type="text" aria-describedby="north-hint"
-    
-        
-      
-    
-   altName="nth">
+  <input class="govuk-input" id="north" name="north" type="text" aria-describedby="north-hint" altName="nth">
 
 </div>
 </div>
           <div class="geography-fields__field">
-
 
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="south">
@@ -342,41 +283,11 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="south" name="south" type="text" aria-describedby="south-hint"
-    
-        
-      
-    
-   altName="sth">
+  <input class="govuk-input" id="south" name="south" type="text" aria-describedby="south-hint" altName="sth">
 
 </div>
 </div>
           <div class="geography-fields__field">
-
 
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="east">
@@ -390,41 +301,11 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="east" name="east" type="text" aria-describedby="east-hint"
-    
-        
-      
-    
-   altName="est">
+  <input class="govuk-input" id="east" name="east" type="text" aria-describedby="east-hint" altName="est">
 
 </div>
 </div>
           <div class="geography-fields__field">
-
 
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="west">
@@ -438,36 +319,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="west" name="west" type="text" aria-describedby="west-hint"
-    
-        
-      
-    
-   altName="wst">
+  <input class="govuk-input" id="west" name="west" type="text" aria-describedby="west-hint" altName="wst">
 
 </div>
 </div>
@@ -498,12 +350,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
     
   
 
-<a href="/search?" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 coordinate-buttons" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-skip="">
+<a href="/search?" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 coordinate-buttons" data-module="govuk-button" data-do-storage-skip="">
   Skip
 </a>
 
@@ -514,15 +361,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0 coordinate-buttons" data-module="govuk-button"
-    
-        
-      
-    
-        
-      
-    
-   data-to-disable="" data-next-question="">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0 coordinate-buttons" data-module="govuk-button" data-to-disable="" data-next-question="">
   See Results
 </button>
 
@@ -536,53 +375,55 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -599,25 +440,21 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -35,129 +35,96 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -181,38 +148,44 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -220,7 +193,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42269%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33311%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -231,8 +204,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
       <div class="govuk-width-container">
         
   
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -249,7 +221,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
 <a href="/date-search" class="govuk-back-link">Back</a>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   
 <div class="govuk-grid-row">
@@ -281,7 +253,6 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
         <div class="geography-fields__container">
           <div class="geography-fields__field">
 
-
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="north">
     North
@@ -294,43 +265,11 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="north" name="north" type="text" value="2" aria-describedby="north-hint"
-    
-        
-      
-    
-   altName="nth">
+  <input class="govuk-input" id="north" name="north" type="text" value="2" aria-describedby="north-hint" altName="nth">
 
 </div>
 </div>
           <div class="geography-fields__field">
-
 
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="south">
@@ -344,43 +283,11 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="south" name="south" type="text" value="2" aria-describedby="south-hint"
-    
-        
-      
-    
-   altName="sth">
+  <input class="govuk-input" id="south" name="south" type="text" value="2" aria-describedby="south-hint" altName="sth">
 
 </div>
 </div>
           <div class="geography-fields__field">
-
 
 <div class="govuk-form-group govuk-!-margin-0">
   <label class="govuk-label" for="east">
@@ -394,48 +301,12 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
   </div>
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input" id="east" name="east" type="text" value="2" aria-describedby="east-hint"
-    
-        
-      
-    
-   altName="est">
+  <input class="govuk-input" id="east" name="east" type="text" value="2" aria-describedby="east-hint" altName="est">
 
 </div>
 </div>
           <div class="geography-fields__field">
 
-
-
-  
-
-  
 <div class="govuk-form-group govuk-form-group--error govuk-!-margin-0">
   <label class="govuk-label" for="west">
     West
@@ -456,38 +327,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     
   </p>
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-   class="govuk-input govuk-input--error govuk-input--error" id="west" name="west" type="text" value="" aria-describedby="west-hint west-error"
-    
-        
-      
-    
-   altName="wst">
+  <input class="govuk-input govuk-input--error govuk-input--error" id="west" name="west" type="text" aria-describedby="west-hint west-error" altName="wst">
 
 </div>
 </div>
@@ -518,12 +358,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     
   
 
-<a href="/search?" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 coordinate-buttons" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-skip="">
+<a href="/search?" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 coordinate-buttons" data-module="govuk-button" data-do-storage-skip="">
   Skip
 </a>
 
@@ -534,15 +369,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0 coordinate-buttons" data-module="govuk-button"
-    
-        
-      
-    
-        
-      
-    
-   data-to-disable="" data-next-question="">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-0 coordinate-buttons" data-module="govuk-button" data-to-disable="" data-next-question="">
   See Results
 </button>
 
@@ -556,53 +383,55 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -619,25 +448,21 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -32,129 +32,96 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -178,38 +145,44 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -227,8 +200,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
   
       <div class="govuk-width-container">
         
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -240,7 +212,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
 </div>
 
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
   <header class="full-width-banner" role="banner">
     <div class="banner-container">
@@ -266,9 +238,6 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
       <form action="/natural-capital-ecosystem-assessment/search" id="keyword" data-do-browser-storage method="post" role="search" class="search-block__form govuk-!-margin-top-6">
         
 
-
-
-  
 <div class="govuk-form-group search-result-input-spacing">
   <label class="govuk-label search-block__label" for="search_term">
     Search
@@ -277,48 +246,9 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
 
   <div class="govuk-input__wrapper">
     
-    
-    <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-        
-      
-    
-    
-    
-    
-   class="govuk-input govuk-input govuk-!-margin-bottom-0 search-block__input" id="search_term" name="search_term" type="text" spellcheck="false" autocomplete="off"
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-   aria-controls="search-results" placeholder="Search" altName="q">
+    <input class="govuk-input govuk-input govuk-!-margin-bottom-0 search-block__input" id="search_term" name="search_term" type="text" spellcheck="false" autocomplete="off" aria-controls="search-results" placeholder="Search" altName="q">
       
     <div class="govuk-input__suffix" aria-hidden="true"><button type="submit" class="search-block__button" data-do-quick-search="true">Search</button></div>
-    
     
   </div>
 
@@ -361,12 +291,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
     
   
 
-<a href="/natural-capital-ecosystem-assessment/classifier-search?level=1" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-quick-search="false" id="guided-search">
+<a href="/natural-capital-ecosystem-assessment/classifier-search?level=1" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button" data-do-quick-search="false" id="guided-search">
   Start
   <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
     <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
@@ -425,53 +350,55 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -488,25 +415,21 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -35,129 +35,96 @@ exports[`Results block template Guided search journey Search results with empty 
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -181,38 +148,44 @@ exports[`Results block template Guided search journey Search results with empty 
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -220,7 +193,7 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46639%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46881%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -231,8 +204,7 @@ exports[`Results block template Guided search journey Search results with empty 
       <div class="govuk-width-container">
         
     
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -249,7 +221,7 @@ exports[`Results block template Guided search journey Search results with empty 
 <a href="#" class="govuk-back-link back-link-search-result">Back</a>
 
   
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     <h1 class="govuk-heading-l ">Search results</h1>
     <div class="govuk-grid-row govuk-!-text-align-right">
@@ -260,12 +232,7 @@ exports[`Results block template Guided search journey Search results with empty 
     
   
 
-<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-reset="">
+<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-do-storage-reset="">
   New search
 </a>
 
@@ -279,13 +246,13 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class='govuk-grid-column-three-quarters govuk-!-margin-0 govuk-!-padding-0 map-view-block'>
       <div id='coordinate-map' style='height: 100%; width: 100%;'></div>
       <div class='defra-map-controls'>
-        <a href="javascript:;" class='defra-map__exit' id="defra-map-exit">
+        <button class='defra-map__exit' id="defra-map-exit">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="25" viewBox="0 0 26 25" fill="none">
             <path d="M24.4846 12.25L4.49219 12.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
             <path d="M14.4889 2.25L3.24316 12.25L14.4889 22.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square"/>
           </svg>
           <span>Exit map</span>
-        </a>
+        </button>
         <div class='defra-map-controls__bottom'>
           <button class='defra-map-reset' id='defra-map-reset' aria-controls="viewport">
             <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="none">
@@ -331,40 +298,32 @@ exports[`Results block template Guided search journey Search results with empty 
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on"
-    
+          
         
-      
-    
-   class="defra-checkboxes__input">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on" class="defra-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="25" viewBox="0 0 32 25" fill="none">
                                 <rect x="0.923077" y="1.17308" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                                 <rect x="10.1535" y="8.55784" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                               </svg>
                               &nbsp;Show all bounding boxes
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -407,12 +366,7 @@ exports[`Results block template Guided search journey Search results with empty 
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button"
-    
-        
-      
-    
-   id="go-to-resource">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button" id="go-to-resource">
   Go to resource
 </button>
 
@@ -423,12 +377,7 @@ exports[`Results block template Guided search journey Search results with empty 
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   id="more-info">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" id="more-info">
   More info
 </button>
 
@@ -441,12 +390,21 @@ exports[`Results block template Guided search journey Search results with empty 
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=&amp;rpp=20&amp;srt=most_relevant&amp;jry=gs&amp;pg=1&amp;scope=all">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           
-
 
 
 <form autocomplete="off" id="filters-search_results">
@@ -1379,147 +1337,53 @@ exports[`Results block template Guided search journey Search results with empty 
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-search_results">
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated before
-    
-    </legend>
-    
-  
-    <div id="date-before-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-before-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-before-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint-search_results date-before-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-search_results" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
 
-</div>
-
-
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated after
-    
-    </legend>
-    
-  
-    <div id="date-after-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-after-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-after-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint-search_results date-after-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-search_results" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
-
-</div>
-
       </div>
     </div>
     <div class="filter-options__container">
@@ -1534,36 +1398,11 @@ exports[`Results block template Guided search journey Search results with empty 
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="licence-search_results" name="licence" type="text" value="">
+  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -1581,36 +1420,11 @@ exports[`Results block template Guided search journey Search results with empty 
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="keywords-search_results" name="keywords" type="text" value="">
+  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -1629,10 +1443,6 @@ exports[`Results block template Guided search journey Search results with empty 
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="/natural-capital-ecosystem-assessment/search?q=&amp;rpp=20&amp;srt=most_relevant&amp;jry=gs&amp;pg=1&amp;scope=all" id="filter-options-reset-search_results" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>
         </div>
@@ -1649,7 +1459,7 @@ exports[`Results block template Guided search journey Search results with empty 
   </h2>
   <div class="govuk-section-break--visible"></div>
   
-    <div class='map-container disabled'>
+    <div class='map-container disabled' id="map-container">
       <div id="map-results-block">
         <button
           id='map-result-button'
@@ -1658,9 +1468,22 @@ exports[`Results block template Guided search journey Search results with empty 
           class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button no-data'
           data-module='govuk-button'
           >
-          
-            No spatial data to display.
-          
+            <span id="no-spatial-data">No spatial data to display.</span>
+            <span id="view-results" class="display-none">
+              View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
+              <svg
+                class='govuk-button__start-icon'
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="20"
+                viewBox="0 0 16 20"
+                fill="none">
+                <path
+                  d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
+                    6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
+                  fill="white"/>
+              </svg>
+            </span>
         </button>
       </div>
     </div>
@@ -1695,53 +1518,55 @@ exports[`Results block template Guided search journey Search results with empty 
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -1758,25 +1583,21 @@ exports[`Results block template Guided search journey Search results with empty 
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>
@@ -1851,129 +1672,96 @@ exports[`Results block template Guided search journey Search results with error 
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -1997,38 +1785,44 @@ exports[`Results block template Guided search journey Search results with error 
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -2036,7 +1830,7 @@ exports[`Results block template Guided search journey Search results with error 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38023%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43325%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2047,8 +1841,7 @@ exports[`Results block template Guided search journey Search results with error 
       <div class="govuk-width-container">
         
     
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -2065,7 +1858,7 @@ exports[`Results block template Guided search journey Search results with error 
 <a href="#" class="govuk-back-link">Back</a>
 
   
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     <h1 class="govuk-heading-l ">Search results</h1>
     <div class="govuk-grid-row govuk-!-text-align-right">
@@ -2076,12 +1869,7 @@ exports[`Results block template Guided search journey Search results with error 
     
   
 
-<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-reset="">
+<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-do-storage-reset="">
   New search
 </a>
 
@@ -2095,13 +1883,13 @@ exports[`Results block template Guided search journey Search results with error 
     <div class='govuk-grid-column-three-quarters govuk-!-margin-0 govuk-!-padding-0 map-view-block'>
       <div id='coordinate-map' style='height: 100%; width: 100%;'></div>
       <div class='defra-map-controls'>
-        <a href="javascript:;" class='defra-map__exit' id="defra-map-exit">
+        <button class='defra-map__exit' id="defra-map-exit">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="25" viewBox="0 0 26 25" fill="none">
             <path d="M24.4846 12.25L4.49219 12.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
             <path d="M14.4889 2.25L3.24316 12.25L14.4889 22.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square"/>
           </svg>
           <span>Exit map</span>
-        </a>
+        </button>
         <div class='defra-map-controls__bottom'>
           <button class='defra-map-reset' id='defra-map-reset' aria-controls="viewport">
             <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="none">
@@ -2147,40 +1935,32 @@ exports[`Results block template Guided search journey Search results with error 
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on"
-    
+          
         
-      
-    
-   class="defra-checkboxes__input">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on" class="defra-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="25" viewBox="0 0 32 25" fill="none">
                                 <rect x="0.923077" y="1.17308" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                                 <rect x="10.1535" y="8.55784" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                               </svg>
                               &nbsp;Show all bounding boxes
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -2223,12 +2003,7 @@ exports[`Results block template Guided search journey Search results with error 
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button"
-    
-        
-      
-    
-   id="go-to-resource">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button" id="go-to-resource">
   Go to resource
 </button>
 
@@ -2239,12 +2014,7 @@ exports[`Results block template Guided search journey Search results with error 
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   id="more-info">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" id="more-info">
   More info
 </button>
 
@@ -2257,12 +2027,21 @@ exports[`Results block template Guided search journey Search results with error 
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-" id="filters-reset-" data-reset-url="">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           
-
 
 
 <form autocomplete="off" id="filters-">
@@ -2303,143 +2082,53 @@ exports[`Results block template Guided search journey Search results with error 
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-">
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-undefined-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated before
-    
-    </legend>
-    
-  
-    <div id="date-before-undefined-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-before-undefined">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-before-undefined-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-undefined-year" name="before-year" type="text" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-before-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint- date-before-error-">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before--year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before--year" name="before-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
 
-</div>
-
-
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-undefined-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated after
-    
-    </legend>
-    
-  
-    <div id="date-after-undefined-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-after-undefined">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-after-undefined-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-undefined-year" name="after-year" type="text" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-after-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint- date-after-error-">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after--year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after--year" name="after-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
-
-</div>
-
       </div>
     </div>
     <div class="filter-options__container">
@@ -2454,34 +2143,11 @@ exports[`Results block template Guided search journey Search results with error 
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="licence-undefined" name="" type="text">
+  <input class="govuk-input" id="licence-undefined" name="" type="text">
 
 </div>
 
@@ -2499,34 +2165,11 @@ exports[`Results block template Guided search journey Search results with error 
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="keywords-undefined" name="" type="text">
+  <input class="govuk-input" id="keywords-undefined" name="" type="text">
 
 </div>
 
@@ -2545,10 +2188,6 @@ exports[`Results block template Guided search journey Search results with error 
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="" id="filter-options-reset-" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>
         </div>
@@ -2575,53 +2214,55 @@ exports[`Results block template Guided search journey Search results with error 
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -2638,25 +2279,21 @@ exports[`Results block template Guided search journey Search results with error 
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>
@@ -2731,129 +2368,96 @@ exports[`Results block template Quick search journey Search results with data sh
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -2877,38 +2481,44 @@ exports[`Results block template Quick search journey Search results with data sh
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -2916,7 +2526,7 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38131%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37869%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2927,8 +2537,7 @@ exports[`Results block template Quick search journey Search results with data sh
       <div class="govuk-width-container">
         
     
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -2945,7 +2554,7 @@ exports[`Results block template Quick search journey Search results with data sh
 <a href="#" class="govuk-back-link back-link-search-result">Back</a>
 
   
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     <h1 class="govuk-heading-l ">Search results</h1>
     <div class="govuk-grid-row govuk-!-text-align-right">
@@ -2956,12 +2565,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-reset="">
+<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-do-storage-reset="">
   New search
 </a>
 
@@ -2975,13 +2579,13 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class='govuk-grid-column-three-quarters govuk-!-margin-0 govuk-!-padding-0 map-view-block'>
       <div id='coordinate-map' style='height: 100%; width: 100%;'></div>
       <div class='defra-map-controls'>
-        <a href="javascript:;" class='defra-map__exit' id="defra-map-exit">
+        <button class='defra-map__exit' id="defra-map-exit">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="25" viewBox="0 0 26 25" fill="none">
             <path d="M24.4846 12.25L4.49219 12.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
             <path d="M14.4889 2.25L3.24316 12.25L14.4889 22.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square"/>
           </svg>
           <span>Exit map</span>
-        </a>
+        </button>
         <div class='defra-map-controls__bottom'>
           <button class='defra-map-reset' id='defra-map-reset' aria-controls="viewport">
             <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="none">
@@ -3027,40 +2631,32 @@ exports[`Results block template Quick search journey Search results with data sh
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on"
-    
+          
         
-      
-    
-   class="defra-checkboxes__input">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on" class="defra-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="25" viewBox="0 0 32 25" fill="none">
                                 <rect x="0.923077" y="1.17308" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                                 <rect x="10.1535" y="8.55784" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                               </svg>
                               &nbsp;Show all bounding boxes
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -3103,12 +2699,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button"
-    
-        
-      
-    
-   id="go-to-resource">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button" id="go-to-resource">
   Go to resource
 </button>
 
@@ -3119,12 +2710,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   id="more-info">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" id="more-info">
   More info
 </button>
 
@@ -3137,12 +2723,21 @@ exports[`Results block template Quick search journey Search results with data sh
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           
-
 
 
 <form autocomplete="off" id="filters-search_results">
@@ -4075,147 +3670,53 @@ exports[`Results block template Quick search journey Search results with data sh
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-search_results">
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated before
-    
-    </legend>
-    
-  
-    <div id="date-before-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-before-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-before-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint-search_results date-before-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-search_results" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
 
-</div>
-
-
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated after
-    
-    </legend>
-    
-  
-    <div id="date-after-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-after-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-after-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint-search_results date-after-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-search_results" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
-
-</div>
-
       </div>
     </div>
     <div class="filter-options__container">
@@ -4230,36 +3731,11 @@ exports[`Results block template Quick search journey Search results with data sh
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="licence-search_results" name="licence" type="text" value="">
+  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -4277,36 +3753,11 @@ exports[`Results block template Quick search journey Search results with data sh
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="keywords-search_results" name="keywords" type="text" value="">
+  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -4325,10 +3776,6 @@ exports[`Results block template Quick search journey Search results with data sh
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all" id="filter-options-reset-search_results" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>
         </div>
@@ -4344,30 +3791,31 @@ exports[`Results block template Quick search journey Search results with data sh
   </h2>
   <div class="govuk-section-break--visible"></div>
   
-    <div class='map-container '>
+    <div class='map-container disabled' id="map-container">
       <div id="map-results-block">
         <button
           id='map-result-button'
           disabled="true"
           onclick="openMapModal()"
-          class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button '
+          class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button no-data'
           data-module='govuk-button'
           >
-          
-            View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
-            <svg
-              class='govuk-button__start-icon'
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="20"
-              viewBox="0 0 16 20"
-              fill="none">
-              <path
-                d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
-                  6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
-                fill="white"/>
-            </svg>
-          
+            <span id="no-spatial-data">No spatial data to display.</span>
+            <span id="view-results" class="display-none">
+              View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
+              <svg
+                class='govuk-button__start-icon'
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="20"
+                viewBox="0 0 16 20"
+                fill="none">
+                <path
+                  d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
+                    6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
+                  fill="white"/>
+              </svg>
+            </span>
         </button>
       </div>
     </div>
@@ -4384,34 +3832,36 @@ exports[`Results block template Quick search journey Search results with data sh
       
 
 
-
 <div class="govuk-form-group option-group">
   <label class="govuk-label option-label" for="sort">
     Sort by
   </label>
 
 
-
   <select class="govuk-select option-block" id="sort" name="sort">
   
     
-    <option value="most_relevant" selected>Most relevant</option>
+      
+      
+      <option value="most_relevant" selected>Most relevant</option>
     
   
     
-    <option value="oldest_study_period">Oldest study period</option>
+      
+      
+      <option value="oldest_study_period">Oldest study period</option>
     
   
     
-    <option value="newest_study_period">Newest study period</option>
+      
+      
+      <option value="newest_study_period">Newest study period</option>
     
   
   </select>
-
 </div>
 
       
-
 
 
 <div class="govuk-form-group option-group">
@@ -4420,23 +3870,27 @@ exports[`Results block template Quick search journey Search results with data sh
   </label>
 
 
-
   <select class="govuk-select option-items" id="page-results" name="page-results">
   
     
-    <option value="20" selected>20</option>
+      
+      
+      <option value="20" selected>20</option>
     
   
     
-    <option value="50">50</option>
+      
+      
+      <option value="50">50</option>
     
   
     
-    <option value="100">100</option>
+      
+      
+      <option value="100">100</option>
     
   
   </select>
-
 </div>
 
     </form>
@@ -4483,12 +3937,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 go-to-resource" data-module="govuk-button"
-    
-        
-      
-    
-   disabled="true">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 go-to-resource" data-module="govuk-button" disabled="true">
   Go to resource
 </button>
 
@@ -4544,12 +3993,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 go-to-resource" data-module="govuk-button"
-    
-        
-      
-    
-   disabled="true">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 go-to-resource" data-module="govuk-button" disabled="true">
   Go to resource
 </button>
 
@@ -4568,27 +4012,11 @@ exports[`Results block template Quick search journey Search results with data sh
       </div>
     
   </div>
-  <nav class="govuk-pagination" aria-label="Pagination">
-  
-  
-  <ul class="govuk-pagination__list">
-  
-    <li class="govuk-pagination__item govuk-pagination__item--current">
-    
-      <a class="govuk-link govuk-pagination__link" href="/natural-capital-ecosystem-assessment/search?q=marine&amp;jry=qs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" aria-label="Page 1" aria-current="page"
-      
-          
-        
-      
-     data-page-id="1">
-        1
-      </a>
-    
-    </li>
-  
-  </ul>
-  
-</nav>
+  <nav class="govuk-pagination" role="navigation" aria-label="Pagination"><ul class="govuk-pagination__list"><li class="govuk-pagination__item govuk-pagination__item--current">
+            <a class="govuk-link govuk-pagination__link" href="/natural-capital-ecosystem-assessment/search?q=marine&amp;jry=qs&amp;pg=1&amp;rpp=20&amp;srt=most_relevant&amp;rty=all" aria-label="Page 1" aria-current="page" data-page-id="1">
+              1
+            </a>
+          </li></ul></nav>
 
 
 
@@ -4607,12 +4035,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   onclick="closeDataModal()">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" onclick="closeDataModal()">
   Cancel
 </button>
 
@@ -4623,15 +4046,7 @@ exports[`Results block template Quick search journey Search results with data sh
     
   
 
-<a href="#" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-        
-      
-    
-   onclick="closeDataModal()" target="_blank" id="resource-locator-link">
+<a href="#" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button" onclick="closeDataModal()" target="_blank" id="resource-locator-link">
   Open site
 </a>
 
@@ -4651,53 +4066,55 @@ exports[`Results block template Quick search journey Search results with data sh
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -4714,25 +4131,21 @@ exports[`Results block template Quick search journey Search results with data sh
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>
@@ -4807,129 +4220,96 @@ exports[`Results block template Quick search journey Search results with empty d
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -4953,38 +4333,44 @@ exports[`Results block template Quick search journey Search results with empty d
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -4992,7 +4378,7 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46399%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33035%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -5003,8 +4389,7 @@ exports[`Results block template Quick search journey Search results with empty d
       <div class="govuk-width-container">
         
     
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -5021,7 +4406,7 @@ exports[`Results block template Quick search journey Search results with empty d
 <a href="#" class="govuk-back-link back-link-search-result">Back</a>
 
   
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     <h1 class="govuk-heading-l ">Search results</h1>
     <div class="govuk-grid-row govuk-!-text-align-right">
@@ -5032,12 +4417,7 @@ exports[`Results block template Quick search journey Search results with empty d
     
   
 
-<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-reset="">
+<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-do-storage-reset="">
   New search
 </a>
 
@@ -5051,13 +4431,13 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class='govuk-grid-column-three-quarters govuk-!-margin-0 govuk-!-padding-0 map-view-block'>
       <div id='coordinate-map' style='height: 100%; width: 100%;'></div>
       <div class='defra-map-controls'>
-        <a href="javascript:;" class='defra-map__exit' id="defra-map-exit">
+        <button class='defra-map__exit' id="defra-map-exit">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="25" viewBox="0 0 26 25" fill="none">
             <path d="M24.4846 12.25L4.49219 12.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
             <path d="M14.4889 2.25L3.24316 12.25L14.4889 22.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square"/>
           </svg>
           <span>Exit map</span>
-        </a>
+        </button>
         <div class='defra-map-controls__bottom'>
           <button class='defra-map-reset' id='defra-map-reset' aria-controls="viewport">
             <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="none">
@@ -5103,40 +4483,32 @@ exports[`Results block template Quick search journey Search results with empty d
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on"
-    
+          
         
-      
-    
-   class="defra-checkboxes__input">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on" class="defra-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="25" viewBox="0 0 32 25" fill="none">
                                 <rect x="0.923077" y="1.17308" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                                 <rect x="10.1535" y="8.55784" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                               </svg>
                               &nbsp;Show all bounding boxes
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -5179,12 +4551,7 @@ exports[`Results block template Quick search journey Search results with empty d
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button"
-    
-        
-      
-    
-   id="go-to-resource">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button" id="go-to-resource">
   Go to resource
 </button>
 
@@ -5195,12 +4562,7 @@ exports[`Results block template Quick search journey Search results with empty d
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   id="more-info">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" id="more-info">
   More info
 </button>
 
@@ -5213,12 +4575,21 @@ exports[`Results block template Quick search journey Search results with empty d
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           
-
 
 
 <form autocomplete="off" id="filters-search_results">
@@ -6151,147 +5522,53 @@ exports[`Results block template Quick search journey Search results with empty d
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-search_results">
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated before
-    
-    </legend>
-    
-  
-    <div id="date-before-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-before-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-before-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint-search_results date-before-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-search_results" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
 
-</div>
-
-
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-search_results-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated after
-    
-    </legend>
-    
-  
-    <div id="date-after-search_results-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-after-search_results">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-                
-              
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-after-group-search_results">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint-search_results date-after-error-search_results">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-search_results" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-search_results" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-search_results"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-search_results">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
-
-</div>
-
       </div>
     </div>
     <div class="filter-options__container">
@@ -6306,36 +5583,11 @@ exports[`Results block template Quick search journey Search results with empty d
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="licence-search_results" name="licence" type="text" value="">
+  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -6353,36 +5605,11 @@ exports[`Results block template Quick search journey Search results with empty d
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-search_results">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="keywords-search_results" name="keywords" type="text" value="">
+  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -6401,10 +5628,6 @@ exports[`Results block template Quick search journey Search results with empty d
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all" id="filter-options-reset-search_results" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>
         </div>
@@ -6421,7 +5644,7 @@ exports[`Results block template Quick search journey Search results with empty d
   </h2>
   <div class="govuk-section-break--visible"></div>
   
-    <div class='map-container disabled'>
+    <div class='map-container disabled' id="map-container">
       <div id="map-results-block">
         <button
           id='map-result-button'
@@ -6430,9 +5653,22 @@ exports[`Results block template Quick search journey Search results with empty d
           class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button no-data'
           data-module='govuk-button'
           >
-          
-            No spatial data to display.
-          
+            <span id="no-spatial-data">No spatial data to display.</span>
+            <span id="view-results" class="display-none">
+              View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
+              <svg
+                class='govuk-button__start-icon'
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="20"
+                viewBox="0 0 16 20"
+                fill="none">
+                <path
+                  d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
+                    6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
+                  fill="white"/>
+              </svg>
+            </span>
         </button>
       </div>
     </div>
@@ -6467,53 +5703,55 @@ exports[`Results block template Quick search journey Search results with empty d
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -6530,25 +5768,21 @@ exports[`Results block template Quick search journey Search results with empty d
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>
@@ -6623,129 +5857,96 @@ exports[`Results block template Quick search journey Search results with error s
   <body class="govuk-template__body app-body-class">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     
-  
-<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service"
-    
-        
-      
-    
-   id="cookie_banner">
-  
-  <div class="govuk-cookie-banner__message govuk-width-container"
-    
-        
-      
-    
-   id="cookie_block" hidden>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on the find natural capital data service" id="cookie_banner">
+    <div class="govuk-cookie-banner__message govuk-width-container" id="cookie_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on the find natural capital data service
-        </h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the find natural capital data service</h2>
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
-          
-        </div>
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button" data-module="govuk-button"
+      <div class="govuk-button-group">
+        
           
-              
+            <button type="button" class="govuk-button" data-module="govuk-button" id="accept_button">
+              Accept analytics cookies
+            </button>
+          
+        
+          
+            <button type="button" class="govuk-button" data-module="govuk-button" id="reject_button">
+              Reject analytics cookies
+            </button>
+          
+        
+          
+            
+              <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
             
           
-         id="accept_button">
-        Accept analytics cookies
-      </button>
-    
-      
-      <button type="button" class="govuk-button" data-module="govuk-button"
-          
-              
-            
-          
-         id="reject_button">
-        Reject analytics cookies
-      </button>
-    
-      
-      <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">View cookies</a>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
         
+      </div>
       
-    
-   id="accept_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've accepted additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
-    </div>
-    
-
-  </div>
-  
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert"
-    
+      <div class="govuk-button-group">
         
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
       
-    
-   id="reject_block" hidden>
+    </div>
+  
+    <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject_block" hidden>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         
+
         <div class="govuk-cookie-banner__content">
-          
-          <p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
-          
-        </div>
+<p class="govuk-body">You've rejected additional cookies. You can <a class="govuk-link help-link" href="/natural-capital-ecosystem-assessment/cookie-policy">change your cookie settings</a> at any time.</p>
+</div>
       </div>
     </div>
 
-    
-    <div class="govuk-button-group">
-    
       
-      <button type="button" class="govuk-button hide_button" data-module="govuk-button">
-        Hide cookie message
-      </button>
-    
+      <div class="govuk-button-group">
+        
+          
+            <button type="button" class="govuk-button hide_button" data-module="govuk-button">
+              Hide cookie message
+            </button>
+          
+        
+      </div>
+      
     </div>
-    
-
-  </div>
   
 </div>
 
@@ -6769,38 +5970,44 @@ exports[`Results block template Quick search journey Search results with error s
     <!-- Google tag (gtag.js) -->
     
 
-    <header class="govuk-header" data-module="govuk-header">
+    
+
+
+
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <svg
-          focusable="false"
-          role="img"
-          class="govuk-header__logotype"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 148 30"
-          height="30"
-          width="148"
-          aria-label="GOV.UK"
-        >
-          <title>GOV.UK</title>
-          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-        </svg>
+        
+<svg
+  focusable="false"
+  role="img"
+  class="govuk-header__logotype"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 148 30"
+  height="30"
+  width="148"
+  aria-label="GOV.UK"
+>
+  <title>GOV.UK</title>
+  <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+</svg>
+
         
       </a>
     </div>
-  
+    
     <div class="govuk-header__content">
     
-      
+    
       <a href="/natural-capital-ecosystem-assessment" class="govuk-header__link govuk-header__service-name">
         Find natural capital data
       </a>
-      
+    
     
     
     </div>
-  
+    
   </div>
 </header>
 
@@ -6808,7 +6015,7 @@ exports[`Results block template Quick search journey Search results with error s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43697%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38527%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -6819,8 +6026,7 @@ exports[`Results block template Quick search journey Search results with error s
       <div class="govuk-width-container">
         
     
-  
-<div class="govuk-phase-banner">
+  <div class="govuk-phase-banner">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       Beta
@@ -6837,7 +6043,7 @@ exports[`Results block template Quick search journey Search results with error s
 <a href="#" class="govuk-back-link">Back</a>
 
   
-        <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
           
     <h1 class="govuk-heading-l ">Search results</h1>
     <div class="govuk-grid-row govuk-!-text-align-right">
@@ -6848,12 +6054,7 @@ exports[`Results block template Quick search journey Search results with error s
     
   
 
-<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-    
-        
-      
-    
-   data-do-storage-reset="">
+<a href="/natural-capital-ecosystem-assessment" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-do-storage-reset="">
   New search
 </a>
 
@@ -6867,13 +6068,13 @@ exports[`Results block template Quick search journey Search results with error s
     <div class='govuk-grid-column-three-quarters govuk-!-margin-0 govuk-!-padding-0 map-view-block'>
       <div id='coordinate-map' style='height: 100%; width: 100%;'></div>
       <div class='defra-map-controls'>
-        <a href="javascript:;" class='defra-map__exit' id="defra-map-exit">
+        <button class='defra-map__exit' id="defra-map-exit">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="25" viewBox="0 0 26 25" fill="none">
             <path d="M24.4846 12.25L4.49219 12.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
             <path d="M14.4889 2.25L3.24316 12.25L14.4889 22.25" stroke="#0B0C0C" stroke-width="2" stroke-linecap="square"/>
           </svg>
           <span>Exit map</span>
-        </a>
+        </button>
         <div class='defra-map-controls__bottom'>
           <button class='defra-map-reset' id='defra-map-reset' aria-controls="viewport">
             <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="none">
@@ -6919,40 +6120,32 @@ exports[`Results block template Quick search journey Search results with error s
 
 
 
-
 <div class="govuk-form-group govuk-!-margin-top-3 govuk-!-margin-bottom-3">
 
   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     
-    
       
-  
-  
-    
-    
-    
-    
-    
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on"
-    
+          
         
-      
-    
-   class="defra-checkboxes__input">
-      <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
+          
+          
+          
+          
+          
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="bounding-box" name="bounding-box" type="checkbox" value="on" class="defra-checkboxes__input">
+            <label class="govuk-label govuk-checkboxes__label defra-checkboxes__label" for="bounding-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="25" viewBox="0 0 32 25" fill="none">
                                 <rect x="0.923077" y="1.17308" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                                 <rect x="10.1535" y="8.55784" width="20.3077" height="14.7692" stroke="#0B0C0C" stroke-width="1.84615"/>
                               </svg>
                               &nbsp;Show all bounding boxes
       </label>
+            
+          </div>
+          
+        
       
-    </div>
-    
-  
-
-    
     
   </div>
 
@@ -6995,12 +6188,7 @@ exports[`Results block template Quick search journey Search results with error s
     
   
 
-<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button"
-    
-        
-      
-    
-   id="go-to-resource">
+<button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-right-1" data-module="govuk-button" id="go-to-resource">
   Go to resource
 </button>
 
@@ -7011,12 +6199,7 @@ exports[`Results block template Quick search journey Search results with error s
     
   
 
-<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button"
-    
-        
-      
-    
-   id="more-info">
+<button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" id="more-info">
   More info
 </button>
 
@@ -7029,12 +6212,21 @@ exports[`Results block template Quick search journey Search results with error s
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-" id="filters-reset-" data-reset-url="">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           
-
 
 
 <form autocomplete="off" id="filters-">
@@ -7075,143 +6267,53 @@ exports[`Results block template Quick search journey Search results with error s
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-">
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-undefined-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated before
-    
-    </legend>
-    
-  
-    <div id="date-before-undefined-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-before-undefined">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-before-undefined-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-undefined-year" name="before-year" type="text" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-before-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint- date-before-error-">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before--year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before--year" name="before-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
 
-</div>
-
-
-        
-
-
-
-
-  
-<div class="govuk-form-group">
-
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-undefined-hint">
-    
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-    
-      Updated after
-    
-    </legend>
-    
-  
-    <div id="date-after-undefined-hint" class="govuk-hint">
-      For example, 2007
-    </div>
-  
-  
-    <div class="govuk-date-input" id="date-after-undefined">
-      
-      
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="date-after-undefined-year">
-            Year
-          </label>
-        
-        
-          <input
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-                
-              
-            
-            
-            
-            
-            
-            
-            
-            
-                
-              
-            
-           class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-undefined-year" name="after-year" type="text" inputmode="numeric">
-        
+        <div class="govuk-form-group" id="date-after-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint- date-after-error-">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after--year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after--year" name="after-year" type="text" value="" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
         </div>
-      </div>
-      
-      
-    </div>
-  
-  </fieldset>
-
-</div>
-
       </div>
     </div>
     <div class="filter-options__container">
@@ -7226,34 +6328,11 @@ exports[`Results block template Quick search journey Search results with error s
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="licence-undefined" name="" type="text">
+  <input class="govuk-input" id="licence-undefined" name="" type="text">
 
 </div>
 
@@ -7271,34 +6350,11 @@ exports[`Results block template Quick search journey Search results with error s
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-">
         
 
-
 <div class="govuk-form-group">
   
 
 
-  <input
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-        
-      
-    
-    
-    
-    
-    
-    
-    
-    
-    
-   class="govuk-input" id="keywords-undefined" name="" type="text">
+  <input class="govuk-input" id="keywords-undefined" name="" type="text">
 
 </div>
 
@@ -7317,10 +6373,6 @@ exports[`Results block template Quick search journey Search results with error s
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="" id="filter-options-reset-" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>
         </div>
@@ -7347,53 +6399,55 @@ exports[`Results block template Quick search journey Search results with error s
 
 
     
-  <footer class="govuk-footer">
+  <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
     
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-        <ul class="govuk-footer__inline-list">
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
-              Help
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
-              Privacy
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
-              Cookies
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
-              Accessibility statement
-            </a>
-          </li>
-        
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
-              Terms and conditions
-            </a>
-          </li>
-        
-        </ul>
-        
-        
-        <div class="govuk-footer__meta-custom">
-          <p>Version: v1.5.1</p>
-        </div>
-        
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          
+            <ul class="govuk-footer__inline-list">
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/help">
+                    Help
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/privacy-policy">
+                    Privacy
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/cookie-policy">
+                    Cookies
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/accessibility-statement">
+                    Accessibility statement
+                  </a>
+                </li>
+              
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="/natural-capital-ecosystem-assessment/terms-conditions">
+                    Terms and conditions
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+            <div class="govuk-footer__meta-custom">
+              
+<p>Version: v1.6.0</p>
+
+            </div>
+          
         
         <svg
           aria-hidden="true"
@@ -7410,25 +6464,21 @@ exports[`Results block template Quick search journey Search results with error s
           />
         </svg>
         <span class="govuk-footer__licence-description">
-        
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
-        
+          
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >
-        
-          © Crown copyright
-        
-        </a>
+        >© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/__tests__/services/handlers/searchApi.spec.ts
+++ b/__tests__/services/handlers/searchApi.spec.ts
@@ -122,7 +122,7 @@ describe('Search API', () => {
         },
         defaultFilters,
       );
-      expect(result).toEqual({ total: 0, items: [] });
+      expect(result).toEqual({ total: 0, items: [], hasSpatialData: false });
     });
   });
 

--- a/__tests__/utils/formatSearchResponse.spec.ts
+++ b/__tests__/utils/formatSearchResponse.spec.ts
@@ -127,6 +127,7 @@ describe('Format the search response', () => {
           toYear: '2009',
         },
       ],
+      hasSpatialData: false,
     };
     const result = await formatSearchResponse(apiResponse);
     expect(result).toEqual(expectedResponse);
@@ -582,6 +583,7 @@ describe('Format the search response', () => {
           },
         },
       ],
+      hasSpatialData: false,
     };
 
     const result = await formatSearchResponse(apiResponse, true);

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -1,3 +1,5 @@
+const filtersInstance = 'search_results';
+
 const searchResultSortFormId = 'sort_results';
 const dateBeforePrefix = 'date-before';
 const dateAfterPrefix = 'date-after';
@@ -95,15 +97,36 @@ const filterFormToFormData = (form) => {
 };
 
 /**
- * Attatch event listener to the form containing the filters
- * so the page responds when filter is changed.
+ * Attatch event listener to the form reset
+ * so it resets the filters correctly, instead of relying on default
+ * reset behaviour.
  *
  * @param {string} instance
  */
-const addFilterFormChangeListener = (instance) => {
+const addFilterFormResetListener = (instance) => {
+  const formSubmit = document.getElementById(`filters-${instance}`);
+  const resetButton = document.getElementById(`filters-reset-${instance}`);
+
+  formSubmit.addEventListener('reset', (e) => {
+    e.preventDefault();
+
+    window.location.href = resetButton.getAttribute('data-reset-url');
+  });
+};
+
+/**
+ * Attatch event listener to the form submission
+ * so the validation can take place before submission.
+ *
+ * @param {string} instance
+ */
+const addFilterFormSubmitListener = (instance) => {
   const form = document.getElementById(`filters-${instance}`);
 
-  form.addEventListener('change', () => {
+  form.addEventListener('submit', (e) => {
+    // prevent form from submitting
+    e.preventDefault();
+
     const data = filterFormToFormData(form);
     const url = new URLSearchParams(data);
     appendMetaSearchParams(url);
@@ -134,7 +157,7 @@ const showDateFilterError = (instance, input, message) => {
   // set the contents of the error message
   $(`#${prefix}-error-message-${instance}`).html(message);
   // apply the error class to the accordion so it is clear where the error is if it is closed
-  $(`[data-category-${instance}='date']`).addClass(formGroupErrorClass);
+  $(`[data-category-${instance}='date']`).addClass('box-shadow-error');
 };
 
 /**
@@ -216,8 +239,9 @@ const attachSearchResultsSortChangeListener = () => {
 document.addEventListener('DOMContentLoaded', () => {
   attachSearchResultsSortChangeListener();
 
-  addCategoryAccordionToggleListeners('search_results');
-  addFilterFormChangeListener('search_results');
+  addCategoryAccordionToggleListeners(filtersInstance);
+  addFilterFormSubmitListener(filtersInstance);
+  addFilterFormResetListener(filtersInstance);
 });
 
 export { addCategoryAccordionToggleListeners, filterFormToFormData, appendMetaSearchParams };

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -1,8 +1,11 @@
-const fromYearId = 'start_year';
-const toYearId = 'to_year';
-const filterSPFormId = 'study_period_filter';
-const filterRTFormId = 'resource_type_filter';
 const searchResultSortFormId = 'sort_results';
+const dateBeforePrefix = 'date-before';
+const dateAfterPrefix = 'date-after';
+
+const formGroupErrorClass = 'govuk-form-group--error';
+const displayNoneClass = 'display-none';
+
+const validYearRegex = /^$|^[0-9]{4}$/; // matches empty string OR 4 digit number
 
 /**
  * Attatch event listeners to the filters accordions so
@@ -105,58 +108,93 @@ const addFilterFormChangeListener = (instance) => {
     const url = new URLSearchParams(data);
     appendMetaSearchParams(url);
 
+    // if the date filters fail to validate, don't submit
+    if (!validateDateFilters(instance)) {
+      return;
+    }
+
     window.location.search = url.toString();
   });
+};
+
+/**
+ * Shows an error messasge for either of the date inputs.
+ *
+ * @param {string} instance
+ * @param {'before' | 'after'} input
+ * @param {string} message
+ */
+const showDateFilterError = (instance, input, message) => {
+  const prefix = input === 'before' ? dateBeforePrefix : dateAfterPrefix;
+
+  // add the govuk error class to the group containing the date field
+  $(`#${prefix}-group-${instance}`).addClass(formGroupErrorClass);
+  // remove the `display: none` from the error message so it appears
+  $(`#${prefix}-error-${instance}`).removeClass(displayNoneClass);
+  // set the contents of the error message
+  $(`#${prefix}-error-message-${instance}`).html(message);
+  // apply the error class to the accordion so it is clear where the error is if it is closed
+  $(`[data-category-${instance}='date']`).addClass(formGroupErrorClass);
+};
+
+/**
+ * Hides any error messasge for either of the date inputs.
+ *
+ * @param {string} instance
+ * @param {'before' | 'after'} input
+ */
+const hideDateFilterError = (instance, input) => {
+  const prefix = input === 'before' ? dateBeforePrefix : dateAfterPrefix;
+
+  $(`#${prefix}-group-${instance}`).remove(formGroupErrorClass);
+  $(`#${prefix}-error-${instance}`).add(displayNoneClass);
+};
+
+/**
+ * Validates the date filters. If they fail to validate it will display an error and the function will return `false`.
+ * Otherwise, it will return `true`/
+ *
+ * @param {string} instance
+ * @returns {boolean}
+ */
+const validateDateFilters = (instance) => {
+  const beforeYear = $(`#${dateBeforePrefix}-${instance}-year`).val();
+  const afterYear = $(`#${dateAfterPrefix}-${instance}-year`).val();
+
+  if (!validYearRegex.test(beforeYear)) {
+    showDateFilterError(instance, 'before', 'Before year must be a valid year.');
+
+    return false;
+  } else {
+    hideDateFilterError(instance, 'before');
+  }
+
+  if (!validYearRegex.test(afterYear)) {
+    showDateFilterError(instance, 'after', 'After year must be a valid year.');
+
+    return false;
+  } else {
+    hideDateFilterError(instance, 'after');
+  }
+
+  // use `Number` instead of `parseInt` as it has stricter rules on what is a valid number
+  // they should be valid here anyway due the the regex validation
+  const nBeforeYear = Number(beforeYear);
+  const nAfterYear = Number(afterYear);
+
+  if (nAfterYear > 0 && nAfterYear < nBeforeYear) {
+    showDateFilterError(instance, 'after', 'After year must be greater than the before year.');
+
+    return false;
+  }
+
+  return true;
 };
 
 const submitSearchResultsFilter = (formId) => {
   const formElement = document.getElementById(formId);
   if (formElement) {
     formElement.submit();
-  }
-};
-
-const updateFromYear = (toYearElement, doSubmit) => {
-  const value = toYearElement.value;
-  const id = toYearElement.getAttribute('id');
-  const instance = id.split('-')[0].trim();
-  const fromYearElement = document.getElementById(`${instance}-${fromYearId}`);
-  if (parseInt(value) < parseInt(fromYearElement.value)) {
-    for (let i = fromYearElement.options.length - 1; i >= 0; i--) {
-      if (parseInt(fromYearElement.options[i].value) <= parseInt(value)) {
-        fromYearElement.value = fromYearElement.options[i].value;
-        if (doSubmit) {
-          setTimeout(() => {
-            submitSearchResultsFilter(`${filterSPFormId}-${instance}`);
-          }, 100);
-        }
-        break;
-      }
-    }
-  } else {
-    doSubmit && submitSearchResultsFilter(`${filterSPFormId}-${instance}`);
-  }
-};
-
-const updateToYear = (startYearElement, doSubmit) => {
-  const value = startYearElement.value;
-  const id = startYearElement.getAttribute('id');
-  const instance = id.split('-')[0].trim();
-  const toYearElement = document.getElementById(`${instance}-${toYearId}`);
-  if (parseInt(value) > parseInt(toYearElement.value)) {
-    for (let i = 0; i < toYearElement.options.length; i++) {
-      if (parseInt(toYearElement.options[i].value) >= parseInt(value)) {
-        toYearElement.value = toYearElement.options[i].value;
-        if (doSubmit) {
-          setTimeout(() => {
-            submitSearchResultsFilter(`${filterSPFormId}-${instance}`);
-          }, 100);
-        }
-        break;
-      }
-    }
-  } else {
-    doSubmit && submitSearchResultsFilter(`${filterSPFormId}-${instance}`);
   }
 };
 

--- a/public/scripts/keywordsFilter.js
+++ b/public/scripts/keywordsFilter.js
@@ -32,6 +32,10 @@ $(document).ready(function () {
         } else {
             params.set('keywords', selectedValue)
         }
-        window.location.search = params.toString();        
+
+        const url = new URL(window.location.href);
+        url.search = params.toString();
+
+        window.history.pushState({}, '', url);
     });
 })

--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -2,6 +2,7 @@ import { fireEventAfterStorage, getStorageData, updateSubmitButtonState } from '
 import { invokeAjaxCall } from './fetchResults.js';
 import { addCategoryAccordionToggleListeners, filterFormToFormData, appendMetaSearchParams } from './filters.js';
 
+const mapResultsInstance = 'map_results';
 const index3 = 3;
 const precision = 6;
 const timeout = 200;
@@ -559,8 +560,8 @@ const attachBoundingBoxToggleListener = () => {
  * Attaches event listener to the form containing the filters in the map view.
  * This is different to the other event listener as it does not refresh the page.
  */
-const attachMapResultsFilterChangeListeners = () => {
-  const form = document.getElementById(`filters-map_results`);
+const attachMapResultsFilterChangeListeners = (instance) => {
+  const form = document.getElementById(`filters-${instance}`);
 
   form.addEventListener('change', (e) => {
     resetData = true;
@@ -573,25 +574,6 @@ const attachMapResultsFilterChangeListeners = () => {
       invokeMapFilters();
     }
 
-    invokeMapResults(true);
-  });
-};
-
-/**
- * Attaches click event listener to the `Reset Filters` link
- */
-const attachResetFiltersClickListener = () => {
-  const link = document.getElementById(`filter-options-reset-map_results`);
-  const form = document.getElementById(`filters-map_results`);
-
-  link.addEventListener('click', (e) => {
-    e.preventDefault();
-
-    resetData = false;
-
-    form.reset();
-
-    invokeMapFilters();
     invokeMapResults(true);
   });
 };
@@ -638,9 +620,8 @@ const getMapFilters = async (path) => {
     const mapFiltersHtml = await response.text();
     document.getElementById(filterBlockId).innerHTML = mapFiltersHtml;
 
-    addCategoryAccordionToggleListeners('map_results');
-    attachMapResultsFilterChangeListeners();
-    attachResetFiltersClickListener();
+    addCategoryAccordionToggleListeners(mapResultsInstance);
+    attachMapResultsFilterChangeListeners(mapResultsInstance);
   }
 };
 

--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -16,6 +16,9 @@ const mapInitialLon = 3.436;
 const mapInitialLat = 55.3781;
 const mapResultsButtonId = 'map-result-button';
 const mapResultsCountId = 'map-result-count';
+const noSpatialDataId = 'no-spatial-data';
+const viewResultsId = 'view-results';
+const mapContainerId = 'map-container';
 const actionDataAttribute = 'data-action';
 const filterBlockId = 'map-filter-block';
 const boundingBoxCheckbox = document.getElementById('bounding-box');
@@ -596,14 +599,22 @@ const attachResetFiltersClickListener = () => {
 const getMapResults = async (path, fitToMapExtentFlag) => {
   const mapResultsButton = document.getElementById(mapResultsButtonId);
   const mapResultsCount = document.getElementById(mapResultsCountId);
+  const noSpatialDataSpan = document.getElementById(noSpatialDataId);
+  const viewResultsSpan = document.getElementById(viewResultsId);
+  const mapContainerDiv = document.getElementById(mapContainerId);
+
   const response = await invokeAjaxCall(path, {}, false, 'GET');
   if (response) {
     if (response.status === responseSuccessStatusCode) {
       const mapResultsJson = await response.json();
-      mapResultsCount.textContent = mapResultsJson.total;
-      if (mapResultsJson.total > 0) {
+
+      if (mapResultsJson.hasSpatialData) {
+        mapResultsCount.textContent = mapResultsJson.total;
         mapResultsButton.removeAttribute('disabled');
-        document.querySelector('.map-container').style.display = 'block';
+        mapContainerDiv.classList.remove('disabled');
+        noSpatialDataSpan.classList.add('display-none');
+        viewResultsSpan.classList.remove('display-none');
+
         const boundingBoxInfo = document.getElementById('defra-bounding-box-info');
         if (boundingBoxInfo && mapResultsJson.total > maxCountForBoundingBoxInfo) {
           boundingBoxInfo.style.display = 'block';
@@ -615,12 +626,8 @@ const getMapResults = async (path, fitToMapExtentFlag) => {
           drawBoundingBoxWithMarker(fitToMapExtentFlag, true);
         }, 100);
         attachBoundingBoxToggleListener();
-      } else {
-        document.querySelector('.map-container').style.display = 'none';
-        mapResultsButton.setAttribute('disabled', true);
       }
-    } else {
-      mapResultsButton.setAttribute('disabled', true);
+      // don't need to handle the `else` cases anymore as it start disabled by default
     }
   }
 };

--- a/src/assets/sass/templates/_results.scss
+++ b/src/assets/sass/templates/_results.scss
@@ -595,18 +595,6 @@
   color: #0b0c0c;
 }
 
-.filter-options__reset-link {
-  font-family: 'GDS Transport', arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #1d70b8;
-  text-decoration: underline;
-
-  &:hover {
-    color: #194578;
-  }
-}
-
 .filter-options__retired-label {
   color: #194578;
 }
@@ -662,4 +650,25 @@
 
 .display-none {
   display: none;
+}
+
+.filters-heading {
+  display: flex;
+  flex-direction: column;
+
+  .filters-buttons {
+    display: flex;
+    gap: 0.5rem;
+
+    button {
+      width: min-content;
+      height: min-content;
+      text-wrap: nowrap;
+      margin-bottom: 1rem;
+    }
+  }
+}
+
+.box-shadow-error {
+  box-shadow: -5px 0px 0px 0px #d4351c;
 }

--- a/src/assets/sass/templates/_results.scss
+++ b/src/assets/sass/templates/_results.scss
@@ -659,3 +659,7 @@
 .govuk-font-family {
   font-family: 'GDS Transport', arial, sans-serif;
 }
+
+.display-none {
+  display: none;
+}

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -145,6 +145,7 @@ export interface TabbedItem {
 export interface ISearchResults {
   total: number;
   items: ISearchItem[];
+  hasSpatialData: boolean;
 }
 
 export interface IAggregationOption {

--- a/src/services/handlers/searchApi.ts
+++ b/src/services/handlers/searchApi.ts
@@ -36,7 +36,7 @@ const getSearchResults = async (
 
       return finalResponse;
     } else {
-      return Promise.resolve({ total: 0, items: [] });
+      return Promise.resolve({ total: 0, items: [], hasSpatialData: false });
     }
     /* eslint-disable  @typescript-eslint/no-explicit-any */
   } catch (error: any) {

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -65,6 +65,7 @@ const formatSearchResponse = async (
   const finalResponse: ISearchResults = {
     total: apiResponse?.hits?.total?.value,
     items: [],
+    hasSpatialData: false,
   };
   let minStartYear: string = '';
   let maxToYear: string = '';
@@ -101,6 +102,8 @@ const formatSearchResponse = async (
     };
 
     if (isMapResults && searchItem._source?.geom != null) {
+      finalResponse.hasSpatialData = true;
+
       const coordinatesData: IAccumulatedCoordinatesWithCenter = getAccumulatedCoordinatesNCenter(
         searchItem._source.geom,
       ) as IAccumulatedCoordinatesWithCenter;
@@ -126,6 +129,7 @@ const formatSearchResponse = async (
   if (isMapResults) {
     finalResponse.total = finalResponse.items.length;
   }
+
   return finalResponse;
 };
 

--- a/src/views/partials/results/filters.njk
+++ b/src/views/partials/results/filters.njk
@@ -172,9 +172,5 @@
         </label>
       </div>
     </div>
-
-    <div class="govuk-!-margin-top-4 govuk-section-break--visible"></div>
-
-    <a href="{{dspFilterReset}}" id="filter-options-reset-{{filterInstance}}" class="filter-options__reset-link govuk-body-m">Reset Filters</a>
   </section>
 </form>

--- a/src/views/partials/results/filters.njk
+++ b/src/views/partials/results/filters.njk
@@ -1,5 +1,4 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 <form autocomplete="off" id="filters-{{filterInstance}}">
@@ -77,47 +76,53 @@
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-{{filterInstance}}">
-        {{ govukDateInput({
-          id: "date-before-"+filterInstance,
-          namePrefix: "before",
-          fieldset: {
-            legend: {
-              text: "Updated before",
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          hint: {
-            text: "For example, 2007"
-          },
-          items: [
-            {
-              classes: "govuk-input--width-4",
-              name: "year",
-              value: dspFilterOptions.lastUpdated.beforeYear
-            }
-          ]
-        }) }}
+        <div class="govuk-form-group" id="date-before-group-{{filterInstance}}">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint-{{filterInstance}} date-before-error-{{filterInstance}}">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated Before
+            </legend>
+            <div id="date-before-hint-{{filterInstance}}" class="govuk-hint">
+              For example, 2004
+            </div>
+            <p id="date-before-error-{{filterInstance}}" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-{{filterInstance}}"></span>
+            </p>
+            <div class="govuk-date-input" id="date-before-{{filterInstance}}">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-before-{{filterInstance}}-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-{{filterInstance}}-year" name="before-year" type="text" value="{{dspFilterOptions.lastUpdated.beforeYear}}" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
 
-        {{ govukDateInput({
-          id: "date-after-"+filterInstance,
-          namePrefix: "after",
-          fieldset: {
-            legend: {
-              text: "Updated after",
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          hint: {
-            text: "For example, 2007"
-          },
-          items: [
-            {
-              classes: "govuk-input--width-4",
-              name: "year",
-              value: dspFilterOptions.lastUpdated.afterYear
-            }
-          ]
-        }) }}
+        <div class="govuk-form-group" id="date-after-group-{{filterInstance}}">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint-{{filterInstance}} date-after-error-{{filterInstance}}">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Updated After
+            </legend>
+            <div id="date-after-hint-{{filterInstance}}" class="govuk-hint">
+              For example, 2015
+            </div>
+            <p id="date-after-error-{{filterInstance}}" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-{{filterInstance}}"></span>
+            </p>
+            <div class="govuk-date-input" id="date-after-{{filterInstance}}">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="date-after-{{filterInstance}}-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-{{filterInstance}}-year" name="after-year" type="text" value="{{dspFilterOptions.lastUpdated.afterYear}}" inputmode="numeric">
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
       </div>
     </div>
     <div class="filter-options__container">

--- a/src/views/partials/results/summary.njk
+++ b/src/views/partials/results/summary.njk
@@ -12,32 +12,31 @@
   </h2>
   <div class="govuk-section-break--visible"></div>
   {% if not hasError %}
-    <div class='map-container {%if not searchResults.total %}disabled{% endif %}'>
+    <div class='map-container disabled' id="map-container">
       <div id="map-results-block">
         <button
           id='map-result-button'
           disabled="true"
           onclick="openMapModal()"
-          class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button {% if not searchResults.total %}no-data{% endif %}'
+          class='govuk-button govuk-button--map govuk-!-margin-bottom-0 spatial-data-button no-data'
           data-module='govuk-button'
           >
-          {% if not searchResults.total %}
-            No spatial data to display.
-          {% else %}
-            View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
-            <svg
-              class='govuk-button__start-icon'
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="20"
-              viewBox="0 0 16 20"
-              fill="none">
-              <path
-                d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
-                  6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
-                fill="white"/>
-            </svg>
-          {% endif %}
+            <span id="no-spatial-data">No spatial data to display.</span>
+            <span id="view-results" class="display-none">
+              View&nbsp;<span id="map-result-count"></span>&nbsp;results on a map
+              <svg
+                class='govuk-button__start-icon'
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="20"
+                viewBox="0 0 16 20"
+                fill="none">
+                <path
+                  d="M14 6C14 2.69 11.31 0 8 0C4.69 0 2 2.69 2 6C2 10.5 8 17 8 17C8 17 14 10.5 14 6ZM6 6C6 4.9 6.9 4 8 4C9.1 4 10 4.9 10
+                    6C10 7.1 9.11 8 8 8C6.9 8 6 7.1 6 6ZM1 18V20H15V18H1Z"
+                  fill="white"/>
+              </svg>
+            </span>
         </button>
       </div>
     </div>

--- a/src/views/screens/results/template.njk
+++ b/src/views/screens/results/template.njk
@@ -23,9 +23,19 @@
       </div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-            Filters
-          </h2>
+          <div class="filters-heading">
+            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+              Filters
+            </h2>
+            <div class="filters-buttons">
+              <button type="reset" class="govuk-button govuk-button--warning" data-module="govuk-button" form="filters-{{filterInstance}}" id="filters-reset-{{filterInstance}}" data-reset-url="{{dspFilterReset}}">
+                Clear Filters
+              </button>
+              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-{{filterInstance}}">
+                Apply Filters
+              </button>
+            </div>
+          </div>
           <div class="govuk-section-break--visible"></div>
           {% include 'partials/results/filters.njk' %}
         </div>


### PR DESCRIPTION
The date filter did not apply any validation to the input so it could be unclear if the date was incorrect when the filter was applied, which would lead the filter to silently fail. I have now added validation to both the `before` and `after` year inputs on the client side the form will not submit until the fields are invalid. This does not prevent the user typing an invalid date directly into the URL but that will be handled by the server-side validation by AGM.

The behaviour of the filters have been changed to requiring a user button press in order to submit the changes. This is better UX than the auto-submission because it allows the user to choose when they want to submit the filters instead of the website guessing for them which can be quite frustrating.

## Testing
### Date filter
Enter an invalid year into either the `before` or `after` fields (invalid is less than 4 characters or anything with a non numeric digit), try and apply the filters and an error should appear and prevent the form submitting and causing a page refresh.
Enter a year into the `before` field that is larger than the `after` field and try and apply the filters. It should also error.

### Filter submit/clear button
Two buttons should be available below the `Filters` heading, one with the text `Clear Filters` and one with `Apply Filters`. Select any number of filters, and alter the filter scope, then apply the filters and the number of results should change.
If you now click `Clear Filters` it should remove any filters applied *but* keep the data scope the same as it was before.