### PR TITLE
Implement filter badges

### DIFF
--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -190,7 +190,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41043%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36245%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -193,7 +193,7 @@ exports[`Details route template Document details with data Check status code and
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38945%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34709%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1540,7 +1540,7 @@ exports[`Details route template Document details with partial data Check status 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45721%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45515%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -193,7 +193,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33311%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35841%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -193,7 +193,7 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46881%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43005%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -452,86 +452,86 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-org-all-search_results" name="org" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-org-search_results" name="org" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-filter-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-filter-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-filter-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-filter-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-filter-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-filter-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-filter-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-filter-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-filter-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-filter-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-filter-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
                   </div>
@@ -559,16 +559,16 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-st-all-search_results" name="st" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-st-search_results" name="st" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-title-filter-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-title-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-search_results">
                       Title
                     </label>
                   </div>
@@ -596,23 +596,23 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-dt-all-search_results" name="dt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-dt-search_results" name="dt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-spatial-filter-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-spatial-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-search_results">
                       Spatial
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-filter-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-search_results">
                       Non-Spatial
                     </label>
                   </div>
@@ -640,86 +640,86 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-svt-all-search_results" name="svt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-svt-search_results" name="svt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-fd-filter-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-fd-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-search_results">
                       HTTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-wr-filter-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-wr-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-search_results">
                       HTTP Web Resource
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-app-filter-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-app-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-search_results">
                       HTTP Application
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-filter-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-search_results">
                       FTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wms-filter-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wms-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-search_results">
                       WMS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wfs-filter-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wfs-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-search_results">
                       WFS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wcs-filter-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wcs-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-search_results">
                       WCS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-esri-filter-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-esri-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-search_results">
                       ESRI REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ogc-filter-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ogc-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-search_results">
                       OGC API Features
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rest-filter-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rest-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-search_results">
                       REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-soap-filter-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-soap-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-search_results">
                       SOAP API
                     </label>
                   </div>
@@ -747,576 +747,576 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-fmt-all-search_results" name="fmt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-fmt-search_results" name="fmt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-filter-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
                       Comma Separate Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-filter-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-filter-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-filter-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-filter-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
                       Shapefile
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-filter-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
                       Plain Text File
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-filter-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
                       MS Excel (XLS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-filter-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-filter-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-filter-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-filter-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-filter-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-filter-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-filter-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-filter-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-filter-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-filter-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-filter-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-filter-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-filter-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-filter-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-filter-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-filter-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-filter-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-filter-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-filter-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-filter-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-filter-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-filter-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-filter-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-filter-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-filter-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-filter-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-filter-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-filter-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-filter-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-filter-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-filter-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lemuel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-filter-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
                       Many DAT formats (DAT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Many XML formats (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-filter-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
                       MapInfo (TAB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-filter-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
                       MapInfo MIF/MID (MIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-filter-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
                       Microsoft Office Pipe Separated Values file format (PSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-filter-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
                       Multi-resolution Seamless Image Database (MrSID)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-filter-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
                       National Transfer Format - OS (NTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-filter-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
                       Open Document Presentation (ODP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-filter-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
                       Open Document Spreadsheet (ODS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-filter-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
                       Open Document Text (ODT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-filter-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
                       Outlook File Template (OFT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Packbit (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - 3D (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - GeoReferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Standardized (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Unreferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-filter-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
                       Portable Network Graphic (PNG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-filter-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
                       Resource Description Framework (RDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Resource Description Framework (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-filter-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
                       Rich Text Format (RTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-filter-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
                       Tab Separated Values (TSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Tagged Image File Format (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-filter-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-filter-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
                       City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-filter-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-filter-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-filter-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-filter-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-filter-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-filter-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-filter-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-filter-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-filter-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-filter-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-filter-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-filter-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-filter-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-filter-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-filter-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
                       Compressed tape archive (TAR.GZ)
                     </label>
                   </div>
@@ -1351,10 +1351,10 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-date-input" id="date-before-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-before-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-before-search_results" name="date-before" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -1375,10 +1375,10 @@ exports[`Results block template Guided search journey Search results with empty 
             <div class="govuk-date-input" id="date-after-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-after-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-after-search_results" name="date-after" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -1402,7 +1402,7 @@ exports[`Results block template Guided search journey Search results with empty 
   
 
 
-  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
+  <input class="govuk-input" id="filters-licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -1424,7 +1424,7 @@ exports[`Results block template Guided search journey Search results with empty 
   
 
 
-  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
+  <input class="govuk-input" id="filters-keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -1437,8 +1437,8 @@ exports[`Results block template Guided search journey Search results with empty 
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-search_results">
+        <input class="govuk-checkboxes__input" id="filters-retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters-retired-archived-search_results">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>
@@ -1457,6 +1457,254 @@ exports[`Results block template Guided search journey Search results with empty 
     0 results found
     
   </h2>
+  <div class="badge-container">
+    
+
+
+
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+
+
+
+
+
+
+
+
+
+  </div>
   <div class="govuk-section-break--visible"></div>
   
     <div class='map-container disabled' id="map-container">
@@ -1627,6 +1875,7 @@ exports[`Results block template Guided search journey Search results with empty 
     </script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
+    <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/badges.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/details.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/keywordsFilter.js"></script>
     <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
@@ -1830,7 +2079,7 @@ exports[`Results block template Guided search journey Search results with error 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43325%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37643%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2082,48 +2331,48 @@ exports[`Results block template Guided search journey Search results with error 
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-">
-        <div class="govuk-form-group" id="date-before-group-">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint- date-before-error-">
+        <div class="govuk-form-group" id="-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="-hint- -error-">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated Before
             </legend>
-            <div id="date-before-hint-" class="govuk-hint">
+            <div id="-hint-" class="govuk-hint">
               For example, 2004
             </div>
-            <p id="date-before-error-" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-"></span>
+            <p id="-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="-error-message-"></span>
             </p>
-            <div class="govuk-date-input" id="date-before-">
+            <div class="govuk-date-input" id="-">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before--year">
+                  <label class="govuk-label govuk-date-input__label" for="filters--">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before--year" name="before-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters--" name="" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
           </fieldset>
         </div>
 
-        <div class="govuk-form-group" id="date-after-group-">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint- date-after-error-">
+        <div class="govuk-form-group" id="-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="-hint- -error-">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated After
             </legend>
-            <div id="date-after-hint-" class="govuk-hint">
+            <div id="-hint-" class="govuk-hint">
               For example, 2015
             </div>
-            <p id="date-after-error-" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-"></span>
+            <p id="-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="-error-message-"></span>
             </p>
-            <div class="govuk-date-input" id="date-after-">
+            <div class="govuk-date-input" id="-">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after--year">
+                  <label class="govuk-label govuk-date-input__label" for="filters--">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after--year" name="after-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters--" name="" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -2132,44 +2381,44 @@ exports[`Results block template Guided search journey Search results with error 
       </div>
     </div>
     <div class="filter-options__container">
-      <label for="filters-licence-accordion-toggle-" class="filter-options__accordion" data-category-="licence">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-licence-accordion-toggle-" class="filter-options__accordion-toggle">
-          <svg id="filters-licence-accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters--accordion-toggle-" class="filter-options__accordion" data-category-="licence">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters--accordion-toggle-" class="filter-options__accordion-toggle">
+          <svg id="filters--accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Licence
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters--filters-">
         
 
 <div class="govuk-form-group">
   
 
 
-  <input class="govuk-input" id="licence-undefined" name="" type="text">
+  <input class="govuk-input" id="filters-undefined-undefined" name="" type="text">
 
 </div>
 
       </div>
     </div>
     <div class="filter-options__container filter-options__keyword-filter">
-      <label for="filters-keywords-accordion-toggle-" class="filter-options__accordion" data-category-="keywords">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-keywords-accordion-toggle-" class="filter-options__accordion-toggle">
-          <svg id="filters-keywords-accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters--accordion-toggle-" class="filter-options__accordion" data-category-="keywords">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters--accordion-toggle-" class="filter-options__accordion-toggle">
+          <svg id="filters--accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Keywords
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters--filters-">
         
 
 <div class="govuk-form-group">
   
 
 
-  <input class="govuk-input" id="keywords-undefined" name="" type="text">
+  <input class="govuk-input" id="filters-undefined-undefined" name="" type="text">
 
 </div>
 
@@ -2182,8 +2431,8 @@ exports[`Results block template Guided search journey Search results with error 
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-"  name="" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-">
+        <input class="govuk-checkboxes__input" id="filters--"  name="" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters--">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>
@@ -2323,6 +2572,7 @@ exports[`Results block template Guided search journey Search results with error 
     </script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
+    <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/badges.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/details.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/keywordsFilter.js"></script>
     <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
@@ -2526,7 +2776,7 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37869%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35975%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2785,86 +3035,86 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-org-all-search_results" name="org" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-org-search_results" name="org" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-filter-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-filter-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-filter-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-filter-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-filter-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-filter-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-filter-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-filter-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-filter-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-filter-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-filter-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
                   </div>
@@ -2892,16 +3142,16 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-st-all-search_results" name="st" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-st-search_results" name="st" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-title-filter-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-title-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-search_results">
                       Title
                     </label>
                   </div>
@@ -2929,23 +3179,23 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-dt-all-search_results" name="dt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-dt-search_results" name="dt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-spatial-filter-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-spatial-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-search_results">
                       Spatial
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-filter-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-search_results">
                       Non-Spatial
                     </label>
                   </div>
@@ -2973,86 +3223,86 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-svt-all-search_results" name="svt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-svt-search_results" name="svt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-fd-filter-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-fd-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-search_results">
                       HTTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-wr-filter-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-wr-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-search_results">
                       HTTP Web Resource
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-app-filter-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-app-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-search_results">
                       HTTP Application
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-filter-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-search_results">
                       FTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wms-filter-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wms-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-search_results">
                       WMS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wfs-filter-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wfs-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-search_results">
                       WFS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wcs-filter-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wcs-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-search_results">
                       WCS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-esri-filter-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-esri-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-search_results">
                       ESRI REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ogc-filter-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ogc-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-search_results">
                       OGC API Features
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rest-filter-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rest-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-search_results">
                       REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-soap-filter-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-soap-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-search_results">
                       SOAP API
                     </label>
                   </div>
@@ -3080,576 +3330,576 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-fmt-all-search_results" name="fmt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-fmt-search_results" name="fmt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-filter-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
                       Comma Separate Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-filter-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-filter-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-filter-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-filter-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
                       Shapefile
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-filter-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
                       Plain Text File
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-filter-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
                       MS Excel (XLS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-filter-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-filter-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-filter-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-filter-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-filter-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-filter-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-filter-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-filter-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-filter-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-filter-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-filter-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-filter-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-filter-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-filter-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-filter-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-filter-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-filter-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-filter-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-filter-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-filter-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-filter-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-filter-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-filter-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-filter-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-filter-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-filter-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-filter-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-filter-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-filter-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-filter-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-filter-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lemuel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-filter-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
                       Many DAT formats (DAT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Many XML formats (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-filter-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
                       MapInfo (TAB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-filter-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
                       MapInfo MIF/MID (MIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-filter-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
                       Microsoft Office Pipe Separated Values file format (PSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-filter-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
                       Multi-resolution Seamless Image Database (MrSID)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-filter-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
                       National Transfer Format - OS (NTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-filter-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
                       Open Document Presentation (ODP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-filter-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
                       Open Document Spreadsheet (ODS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-filter-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
                       Open Document Text (ODT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-filter-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
                       Outlook File Template (OFT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Packbit (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - 3D (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - GeoReferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Standardized (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Unreferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-filter-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
                       Portable Network Graphic (PNG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-filter-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
                       Resource Description Framework (RDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Resource Description Framework (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-filter-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
                       Rich Text Format (RTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-filter-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
                       Tab Separated Values (TSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Tagged Image File Format (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-filter-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-filter-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
                       City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-filter-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-filter-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-filter-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-filter-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-filter-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-filter-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-filter-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-filter-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-filter-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-filter-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-filter-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-filter-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-filter-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-filter-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-filter-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
                       Compressed tape archive (TAR.GZ)
                     </label>
                   </div>
@@ -3684,10 +3934,10 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-date-input" id="date-before-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-before-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-before-search_results" name="date-before" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -3708,10 +3958,10 @@ exports[`Results block template Quick search journey Search results with data sh
             <div class="govuk-date-input" id="date-after-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-after-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-after-search_results" name="date-after" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -3735,7 +3985,7 @@ exports[`Results block template Quick search journey Search results with data sh
   
 
 
-  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
+  <input class="govuk-input" id="filters-licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -3757,7 +4007,7 @@ exports[`Results block template Quick search journey Search results with data sh
   
 
 
-  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
+  <input class="govuk-input" id="filters-keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -3770,8 +4020,8 @@ exports[`Results block template Quick search journey Search results with data sh
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-search_results">
+        <input class="govuk-checkboxes__input" id="filters-retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters-retired-archived-search_results">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>
@@ -3789,6 +4039,254 @@ exports[`Results block template Quick search journey Search results with data sh
   <h2 class='govuk-heading-m results-stats govuk-!-margin-bottom-2'>
     2 results
   </h2>
+  <div class="badge-container">
+    
+
+
+
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+
+
+
+
+
+
+
+
+
+  </div>
   <div class="govuk-section-break--visible"></div>
   
     <div class='map-container disabled' id="map-container">
@@ -4175,6 +4673,7 @@ exports[`Results block template Quick search journey Search results with data sh
     </script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
+    <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/badges.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/details.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/keywordsFilter.js"></script>
     <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
@@ -4378,7 +4877,7 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33035%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35155%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -4637,86 +5136,86 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-org-all-search_results" name="org" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-org-search_results" name="org" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-org-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-filter-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-filter-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-filter-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-filter-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-filter-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-filter-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-filter-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-filter-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-filter-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-filter-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-filter-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
                   </div>
@@ -4744,16 +5243,16 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-st-all-search_results" name="st" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-st-search_results" name="st" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-st-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-title-filter-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-title-search_results" name="st" type="checkbox" value="title" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-title-search_results">
                       Title
                     </label>
                   </div>
@@ -4781,23 +5280,23 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-dt-all-search_results" name="dt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-dt-search_results" name="dt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-dt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-spatial-filter-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-spatial-search_results" name="dt" type="checkbox" value="spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-spatial-search_results">
                       Spatial
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-filter-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-non-spatial-search_results" name="dt" type="checkbox" value="non-spatial" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-non-spatial-search_results">
                       Non-Spatial
                     </label>
                   </div>
@@ -4825,86 +5324,86 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-svt-all-search_results" name="svt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-svt-search_results" name="svt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-svt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-fd-filter-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-fd-search_results" name="svt" type="checkbox" value="http-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-fd-search_results">
                       HTTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-wr-filter-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-wr-search_results" name="svt" type="checkbox" value="http-wr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-wr-search_results">
                       HTTP Web Resource
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-http-app-filter-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-http-app-search_results" name="svt" type="checkbox" value="http-app" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-http-app-search_results">
                       HTTP Application
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-filter-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ftp-fd-search_results" name="svt" type="checkbox" value="ftp-fd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ftp-fd-search_results">
                       FTP File Download
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wms-filter-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wms-search_results" name="svt" type="checkbox" value="wms" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wms-search_results">
                       WMS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wfs-filter-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wfs-search_results" name="svt" type="checkbox" value="wfs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wfs-search_results">
                       WFS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wcs-filter-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wcs-search_results" name="svt" type="checkbox" value="wcs" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wcs-search_results">
                       WCS
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-esri-filter-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-esri-search_results" name="svt" type="checkbox" value="esri" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-esri-search_results">
                       ESRI REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ogc-filter-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ogc-search_results" name="svt" type="checkbox" value="ogc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ogc-search_results">
                       OGC API Features
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rest-filter-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rest-search_results" name="svt" type="checkbox" value="rest" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rest-search_results">
                       REST API
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-soap-filter-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-soap-search_results" name="svt" type="checkbox" value="soap" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-soap-search_results">
                       SOAP API
                     </label>
                   </div>
@@ -4932,576 +5431,576 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input"  id="filters-fmt-all-search_results" name="fmt" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-all-search_results">
+                  <input class="govuk-checkboxes__input"  id="filters-fmt-search_results" name="fmt" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-fmt-search_results">
                     All
                   </label>
                 </div>
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-filter-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
                       Comma Separate Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-filter-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-filter-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-filter-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-filter-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
                       Shapefile
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-filter-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
                       Plain Text File
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-filter-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
                       MS Excel (XLS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-filter-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-filter-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-filter-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-filter-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-filter-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-filter-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-filter-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-filter-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-filter-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-filter-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-filter-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-filter-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-filter-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-filter-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-filter-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-filter-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-filter-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-filter-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-filter-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-filter-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-filter-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-filter-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-filter-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-filter-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-filter-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-filter-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-filter-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-filter-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-filter-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-filter-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-filter-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lemuel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-filter-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
                       Many DAT formats (DAT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Many XML formats (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-filter-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
                       MapInfo (TAB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-filter-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
                       MapInfo MIF/MID (MIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-filter-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
                       Microsoft Office Pipe Separated Values file format (PSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-filter-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
                       Multi-resolution Seamless Image Database (MrSID)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-filter-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
                       National Transfer Format - OS (NTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-filter-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
                       Open Document Presentation (ODP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-filter-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
                       Open Document Spreadsheet (ODS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-filter-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
                       Open Document Text (ODT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-filter-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
                       Outlook File Template (OFT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Packbit (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - 3D (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - GeoReferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Standardized (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-filter-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
                       Portable Document Format - Unreferenced (PDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-filter-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
                       Portable Network Graphic (PNG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-filter-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
                       Resource Description Framework (RDF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-filter-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
                       Resource Description Framework (XML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-filter-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
                       Rich Text Format (RTF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-filter-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
                       Tab Separated Values (TSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Tagged Image File Format (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-filter-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-filter-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-filter-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
                       City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-filter-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-filter-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-filter-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-filter-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-filter-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-filter-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-filter-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-filter-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-filter-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-filter-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-filter-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-filter-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-filter-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-filter-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-filter-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-filter-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-filter-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
                       Compressed tape archive (TAR.GZ)
                     </label>
                   </div>
@@ -5536,10 +6035,10 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-date-input" id="date-before-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-before-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-search_results-year" name="before-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-before-search_results" name="date-before" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -5560,10 +6059,10 @@ exports[`Results block template Quick search journey Search results with empty d
             <div class="govuk-date-input" id="date-after-search_results">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after-search_results-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-date-after-search_results">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-search_results-year" name="after-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-date-after-search_results" name="date-after" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -5587,7 +6086,7 @@ exports[`Results block template Quick search journey Search results with empty d
   
 
 
-  <input class="govuk-input" id="licence-search_results" name="licence" type="text">
+  <input class="govuk-input" id="filters-licence-search_results" name="licence" type="text">
 
 </div>
 
@@ -5609,7 +6108,7 @@ exports[`Results block template Quick search journey Search results with empty d
   
 
 
-  <input class="govuk-input" id="keywords-search_results" name="keywords" type="text">
+  <input class="govuk-input" id="filters-keywords-search_results" name="keywords" type="text">
 
 </div>
 
@@ -5622,8 +6121,8 @@ exports[`Results block template Quick search journey Search results with empty d
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-search_results">
+        <input class="govuk-checkboxes__input" id="filters-retired-archived-search_results"  name="retired-archived" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters-retired-archived-search_results">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>
@@ -5642,6 +6141,254 @@ exports[`Results block template Quick search journey Search results with empty d
     0 results found
     
   </h2>
+  <div class="badge-container">
+    
+
+
+
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+  
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+    
+  
+
+
+
+
+
+
+
+
+
+
+  </div>
   <div class="govuk-section-break--visible"></div>
   
     <div class='map-container disabled' id="map-container">
@@ -5812,6 +6559,7 @@ exports[`Results block template Quick search journey Search results with empty d
     </script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
+    <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/badges.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/details.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/keywordsFilter.js"></script>
     <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
@@ -6015,7 +6763,7 @@ exports[`Results block template Quick search journey Search results with error s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38527%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37407%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -6267,48 +7015,48 @@ exports[`Results block template Quick search journey Search results with error s
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-">
-        <div class="govuk-form-group" id="date-before-group-">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint- date-before-error-">
+        <div class="govuk-form-group" id="-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="-hint- -error-">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated Before
             </legend>
-            <div id="date-before-hint-" class="govuk-hint">
+            <div id="-hint-" class="govuk-hint">
               For example, 2004
             </div>
-            <p id="date-before-error-" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-"></span>
+            <p id="-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="-error-message-"></span>
             </p>
-            <div class="govuk-date-input" id="date-before-">
+            <div class="govuk-date-input" id="-">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before--year">
+                  <label class="govuk-label govuk-date-input__label" for="filters--">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before--year" name="before-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters--" name="" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
           </fieldset>
         </div>
 
-        <div class="govuk-form-group" id="date-after-group-">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint- date-after-error-">
+        <div class="govuk-form-group" id="-group-">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="-hint- -error-">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated After
             </legend>
-            <div id="date-after-hint-" class="govuk-hint">
+            <div id="-hint-" class="govuk-hint">
               For example, 2015
             </div>
-            <p id="date-after-error-" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-"></span>
+            <p id="-error-" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="-error-message-"></span>
             </p>
-            <div class="govuk-date-input" id="date-after-">
+            <div class="govuk-date-input" id="-">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after--year">
+                  <label class="govuk-label govuk-date-input__label" for="filters--">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after--year" name="after-year" type="text" value="" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters--" name="" type="text" value="" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -6317,44 +7065,44 @@ exports[`Results block template Quick search journey Search results with error s
       </div>
     </div>
     <div class="filter-options__container">
-      <label for="filters-licence-accordion-toggle-" class="filter-options__accordion" data-category-="licence">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-licence-accordion-toggle-" class="filter-options__accordion-toggle">
-          <svg id="filters-licence-accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters--accordion-toggle-" class="filter-options__accordion" data-category-="licence">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters--accordion-toggle-" class="filter-options__accordion-toggle">
+          <svg id="filters--accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Licence
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters--filters-">
         
 
 <div class="govuk-form-group">
   
 
 
-  <input class="govuk-input" id="licence-undefined" name="" type="text">
+  <input class="govuk-input" id="filters-undefined-undefined" name="" type="text">
 
 </div>
 
       </div>
     </div>
     <div class="filter-options__container filter-options__keyword-filter">
-      <label for="filters-keywords-accordion-toggle-" class="filter-options__accordion" data-category-="keywords">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-keywords-accordion-toggle-" class="filter-options__accordion-toggle">
-          <svg id="filters-keywords-accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters--accordion-toggle-" class="filter-options__accordion" data-category-="keywords">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters--accordion-toggle-" class="filter-options__accordion-toggle">
+          <svg id="filters--accordion-icon-" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Keywords
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters--filters-">
         
 
 <div class="govuk-form-group">
   
 
 
-  <input class="govuk-input" id="keywords-undefined" name="" type="text">
+  <input class="govuk-input" id="filters-undefined-undefined" name="" type="text">
 
 </div>
 
@@ -6367,8 +7115,8 @@ exports[`Results block template Quick search journey Search results with error s
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-"  name="" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-">
+        <input class="govuk-checkboxes__input" id="filters--"  name="" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters--">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>
@@ -6508,6 +7256,7 @@ exports[`Results block template Quick search journey Search results with error s
     </script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
+    <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/badges.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/details.js"></script>
     <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/keywordsFilter.js"></script>
     <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>

--- a/__tests__/services/handlers/searchApi.spec.ts
+++ b/__tests__/services/handlers/searchApi.spec.ts
@@ -147,7 +147,7 @@ describe('Search API', () => {
         searchFieldsObject,
         {
           ...defaultFilters,
-          keywords: 'april',
+          keywords: ['april'],
         },
         false,
         true,

--- a/public/scripts/badges.js
+++ b/public/scripts/badges.js
@@ -1,0 +1,43 @@
+/**
+ * Takes any input element and resets it's value. As opposed to resetting the whole form, which is
+ * undesierable, this will reset just a single input.
+ */
+const resetInputElement = (element) => {
+  // add more types to this if more filter input types are added
+  switch (element.attr('type')) {
+    case 'text':
+    case 'number':
+      $(element).val('');
+      break;
+    case 'checkbox':
+      element.prop('checked', false);
+      break;
+  }
+};
+
+/**
+ * Attaches the click event listeners to the badges so they can remove
+ * their filters when clicked.
+ * @param {string} instance
+ */
+const addBadgeClickEventListeners = () => {
+  const badges = $('[data-badge-button]');
+  badges.each(function () {
+    const badge = $(this);
+
+    badge.on('click', () => {
+      // gets the id of the filter input the badge is associated with
+      // this is needed because when a badge is clicked it resets the filter it is associated with
+      const inputId = badge.attr('data-input');
+
+      const input = $(`#${inputId}`);
+      resetInputElement(input);
+
+      badge.remove();
+    });
+  });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  addBadgeClickEventListeners();
+});

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -181,8 +181,8 @@ const hideDateFilterError = (instance, input) => {
  * @returns {boolean}
  */
 const validateDateFilters = (instance) => {
-  const beforeYear = $(`#${dateBeforePrefix}-${instance}-year`).val();
-  const afterYear = $(`#${dateAfterPrefix}-${instance}-year`).val();
+  const beforeYear = $(`#filters-${dateBeforePrefix}-${instance}`).val();
+  const afterYear = $(`#filters-${dateAfterPrefix}-${instance}`).val();
 
   if (!validYearRegex.test(beforeYear)) {
     showDateFilterError(instance, 'before', 'Before year must be a valid year.');
@@ -244,4 +244,4 @@ document.addEventListener('DOMContentLoaded', () => {
   addFilterFormResetListener(filtersInstance);
 });
 
-export { addCategoryAccordionToggleListeners, filterFormToFormData, appendMetaSearchParams };
+export { addCategoryAccordionToggleListeners, filterFormToFormData, appendMetaSearchParams, filtersInstance };

--- a/public/scripts/keywordsFilter.js
+++ b/public/scripts/keywordsFilter.js
@@ -12,8 +12,8 @@ $(document).ready(function () {
             $(".filter-options__keyboard-filter-list").append(liElement)     
         }
     });
-    $('#keywords-search_results').val('');
-    $('#keywords-search_results').on('input', $.debounce(300, function() {
+    $('#filters-keywords-search_results').val('');
+    $('#filters-keywords-search_results').on('input', $.debounce(300, function() {
         const value = $(this).val().toLowerCase();
         $('.filter-options__keyboard-filter-list li').filter(function () {
             $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1);
@@ -22,7 +22,7 @@ $(document).ready(function () {
     }));
     $('#keyboard-filter-list').on('click', 'li', function () {
         const selectedValue = $(this).text()
-        $('#keywords-search_results').val(selectedValue);
+        $('#filters-keywords-search_results').val(selectedValue);
         $('.filter-options__keyboard-filter-content').hide();
 
         const params = new URLSearchParams(window.location.search);

--- a/src/assets/sass/templates/_results.scss
+++ b/src/assets/sass/templates/_results.scss
@@ -680,7 +680,7 @@
   gap: 0.5rem;
   border-radius: 0.5rem;
 
-  // only apply padding and margin if there are badges as childred
+  // only apply padding and margin if there are badges as children
   &:has(> .badge-button) {
     padding: 0.5rem;
     margin-bottom: 1rem;

--- a/src/assets/sass/templates/_results.scss
+++ b/src/assets/sass/templates/_results.scss
@@ -672,3 +672,40 @@
 .box-shadow-error {
   box-shadow: -5px 0px 0px 0px #d4351c;
 }
+
+.badge-container {
+  background-color: #f3f2f1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+
+  // only apply padding and margin if there are badges as childred
+  &:has(> .badge-button) {
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  // mostly copied from the core platform `.ag-tag-group button` styles
+  .badge-button {
+    all: unset;
+    border: 1px solid #000;
+    border-radius: 0.25rem;
+    box-shadow: #929191 0px 0px 0px;
+    font-size: 1rem;
+    padding: 0.25rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.25rem;
+
+    &:hover {
+      background-color: #dbdad9;
+    }
+
+    &:active {
+      transform: translateY(2px);
+    }
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -248,7 +248,7 @@ export const naturalTabStaticData = {
 
 export const defaultFilters: ISearchFiltersProcessed = {
   nceaOnly: false,
-  keywords: '',
+  keywords: [''],
   license: '',
   categories: [],
   lastUpdated: {

--- a/src/utils/processFilterRSortOptions.ts
+++ b/src/utils/processFilterRSortOptions.ts
@@ -58,7 +58,11 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
   return {
     nceaOnly,
     categories: categories,
-    keywords: readQueryParams(requestQuery, filterNames.keywords),
+    // without the filter if they keywords are empty it will return a 1 element array
+    // where the element is just an emprty string
+    keywords: readQueryParams(requestQuery, filterNames.keywords)
+      .split(',')
+      .filter((k) => k),
     license: readQueryParams(requestQuery, filterNames.licence),
     lastUpdated: {
       beforeYear: readQueryParams(requestQuery, filterNames.updatedBeforeYear),

--- a/src/utils/processFilterRSortOptions.ts
+++ b/src/utils/processFilterRSortOptions.ts
@@ -65,8 +65,8 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
       .filter((k) => k),
     license: readQueryParams(requestQuery, filterNames.licence),
     lastUpdated: {
-      beforeYear: readQueryParams(requestQuery, filterNames.updatedBeforeYear),
-      afterYear: readQueryParams(requestQuery, filterNames.updatedAfterYear),
+      beforeYear: readQueryParams(requestQuery, filterNames.updatedBefore),
+      afterYear: readQueryParams(requestQuery, filterNames.updatedAfter),
     },
     retiredAndArchived: readQueryParams(requestQuery, filterNames.retiredAndArchived) === 'true',
   };

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -10,8 +10,8 @@ export const filterNames = {
   retiredAndArchived: 'retired-archived',
   keywords: 'keywords',
   licence: 'licence',
-  updatedBeforeYear: 'before-year',
-  updatedAfterYear: 'after-year',
+  updatedBefore: 'date-before',
+  updatedAfter: 'date-after',
 };
 
 export enum DataScopeValues {

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -42,7 +42,7 @@ export type ISearchFilters = ISearchFilter[];
 export interface ISearchFiltersProcessed {
   nceaOnly: boolean;
   categories: ISearchFilterProcessed[];
-  keywords: string;
+  keywords: string[];
   license: string;
   lastUpdated: {
     beforeYear: string;
@@ -116,7 +116,7 @@ export const applyMockFilters = (
 
   if (filters.keywords.length > 0) {
     // split keywords by a few different delimiters
-    const keywords = filters.keywords.split(/, |,| /).map((k) => k.trim());
+    const keywords = filters.keywords.map((k) => k.trim());
 
     results.hits = results.hits.filter((hit) => {
       return keywords.some((keyword) => {

--- a/src/views/macros/icons/cross.njk
+++ b/src/views/macros/icons/cross.njk
@@ -1,0 +1,10 @@
+<svg 
+  stroke="currentColor" 
+  fill="currentColor" 
+  stroke-width="0" 
+  viewBox="0 0 512 512" 
+  xmlns="http://www.w3.org/2000/svg"
+  {{keys}}
+>
+  <path d="M289.94 256l95-95A24 24 0 00351 127l-95 95-95-95a24 24 0 00-34 34l95 95-95 95a24 24 0 1034 34l95-95 95 95a24 24 0 0034-34z"></path>
+</svg>

--- a/src/views/macros/icons/icon.njk
+++ b/src/views/macros/icons/icon.njk
@@ -1,0 +1,10 @@
+{# based on https://www.trysmudford.com/blog/encapsulated-11ty-components/ #}
+{% macro icon(name, params) %}
+  {% set keys = "" %}
+  {# create a list of attributes from the object that is passed in #}
+  {% for key, value in params %}
+    {% set keys = keys + " " + key + "=" + value %}
+  {% endfor %}
+  {# the icon just needs to use `{{keys}}` in the attributes to insert the generated attributes #}
+  {% include "macros/icons/" + name + ".njk" %}
+{% endmacro %}

--- a/src/views/partials/results/badges.njk
+++ b/src/views/partials/results/badges.njk
@@ -1,7 +1,7 @@
 {% from "macros/icons/icon.njk" import icon %}
 
 {% macro badge(badgeName, badgeValue, inputId) %}
-<button class="badge-button" data-input="filters-{{inputId}}-{{filterInstance}}">
+<button class="badge-button" data-input="filters-{{inputId}}-{{filterInstance}}" data-badge-button>
   {# `inputId` holds the id to the filter input that the badge is for #}
   <span class="govuk-font-family">{{ badgeName }}: {{badgeValue}}</span>
   {{ icon("cross", {

--- a/src/views/partials/results/badges.njk
+++ b/src/views/partials/results/badges.njk
@@ -1,7 +1,8 @@
 {% from "macros/icons/icon.njk" import icon %}
 
-{% macro badge(badgeName, badgeValue) %}
-<button class="badge-button">
+{% macro badge(badgeName, badgeValue, inputId) %}
+<button class="badge-button" data-input="filters-{{inputId}}-{{filterInstance}}">
+  {# `inputId` holds the id to the filter input that the badge is for #}
   <span class="govuk-font-family">{{ badgeName }}: {{badgeValue}}</span>
   {{ icon("cross", {
     width: "1rem",
@@ -16,27 +17,27 @@
   {% else %}
     {% for filter in category.filters %}
       {% if filter.checked %}
-        {{ badge(category.name, filter.name) }}
+        {{ badge(category.name, filter.name, filter.value) }}
       {% endif %}
     {% endfor %}
   {% endif %}
 {% endfor %}
 
 {% if (dspFilterOptions.lastUpdated.beforeYear | length) > 0 %}
-  {{ badge("Date Before", dspFilterOptions.lastUpdated.beforeYear) }}
+  {{ badge("Date Before", dspFilterOptions.lastUpdated.beforeYear, dspFilterNames.updatedBefore) }}
 {% endif %}
 {% if (dspFilterOptions.lastUpdated.afterYear | length) > 0 %}
-  {{ badge("Date After", dspFilterOptions.lastUpdated.afterYear) }}
+  {{ badge("Date After", dspFilterOptions.lastUpdated.afterYear,  dspFilterNames.updatedAfter) }}
 {% endif %}
 
 {% if (dspFilterOptions.license | length) > 0 %}
-  {{ badge("License", dspFilterOptions.license) }}
+  {{ badge("License", dspFilterOptions.license,  dspFilterNames.licence) }}
 {% endif %}
 
 {% for keyword in dspFilterOptions.keywords %}
-  {{ badge("Keyword", keyword) }}
+  {{ badge("Keyword", keyword,  dspFilterNames.keywords) }}
 {% endfor %}
 
 {% if dspFilterOptions.retiredAndArchived %}
-  {{ badge("Retired and Archived records", "Yes") }}
+  {{ badge("Retired and Archived records", "Yes", dspFilterNames.retiredAndArchived) }}
 {% endif %}

--- a/src/views/partials/results/badges.njk
+++ b/src/views/partials/results/badges.njk
@@ -1,0 +1,42 @@
+{% from "macros/icons/icon.njk" import icon %}
+
+{% macro badge(badgeName, badgeValue) %}
+<button class="badge-button">
+  <span class="govuk-font-family">{{ badgeName }}: {{badgeValue}}</span>
+  {{ icon("cross", {
+    width: "1rem",
+    height: "1rem"
+  }) }}
+</button>
+{% endmacro %}
+
+{% for category in dspFilterOptions.categories %}
+  {% if category.selectedAll %}
+    {{ badge(category.name, "All") }}
+  {% else %}
+    {% for filter in category.filters %}
+      {% if filter.checked %}
+        {{ badge(category.name, filter.name) }}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+{% if (dspFilterOptions.lastUpdated.beforeYear | length) > 0 %}
+  {{ badge("Date Before", dspFilterOptions.lastUpdated.beforeYear) }}
+{% endif %}
+{% if (dspFilterOptions.lastUpdated.afterYear | length) > 0 %}
+  {{ badge("Date After", dspFilterOptions.lastUpdated.afterYear) }}
+{% endif %}
+
+{% if (dspFilterOptions.license | length) > 0 %}
+  {{ badge("License", dspFilterOptions.license) }}
+{% endif %}
+
+{% for keyword in dspFilterOptions.keywords %}
+  {{ badge("Keyword", keyword) }}
+{% endfor %}
+
+{% if dspFilterOptions.retiredAndArchived %}
+  {{ badge("Retired and Archived records", "Yes") }}
+{% endif %}

--- a/src/views/partials/results/filters.njk
+++ b/src/views/partials/results/filters.njk
@@ -154,8 +154,7 @@
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-{{filterInstance}}">
         {{ govukInput({
           id: "keywords-"+filterInstance,
-          name: dspFilterNames.keywords,
-          value: dspFilterOptions.keywords
+          name: dspFilterNames.keywords
         }) }}
       </div>
       <div class="filter-options__keyboard-filter-content">

--- a/src/views/partials/results/filters.njk
+++ b/src/views/partials/results/filters.njk
@@ -46,16 +46,16 @@
             <div class="govuk-form-group">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                  <input class="govuk-checkboxes__input" {% if category.selectedAll %}checked{% endif %} id="filters-{{category.value}}-all-{{filterInstance}}" name="{{category.value}}" type="checkbox" value="all">
-                  <label class="govuk-label govuk-checkboxes__label" for="filters-{{category.value}}-all-{{filterInstance}}">
+                  <input class="govuk-checkboxes__input" {% if category.selectedAll %}checked{% endif %} id="filters-{{category.value}}-{{filterInstance}}" name="{{category.value}}" type="checkbox" value="all">
+                  <label class="govuk-label govuk-checkboxes__label" for="filters-{{category.value}}-{{filterInstance}}">
                     All
                   </label>
                 </div>
 
                 {% for filter in category.filters %}
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input" {% if filter.checked %}checked{% endif %} id="filters-{{filter.value}}-filter-{{filterInstance}}" name="{{category.value}}" type="checkbox" value="{{filter.value}}" data-multiple="true" data-ncea-only="{{ filter.hasNCEAData }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-{{filter.value}}-filter-{{filterInstance}}">
+                    <input class="govuk-checkboxes__input" {% if filter.checked %}checked{% endif %} id="filters-{{filter.value}}-{{filterInstance}}" name="{{category.value}}" type="checkbox" value="{{filter.value}}" data-multiple="true" data-ncea-only="{{ filter.hasNCEAData }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-{{filter.value}}-{{filterInstance}}">
                       {{filter.name}}
                     </label>
                   </div>
@@ -76,48 +76,48 @@
         </button>
       </label>
       <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-date-filters-{{filterInstance}}">
-        <div class="govuk-form-group" id="date-before-group-{{filterInstance}}">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-before-hint-{{filterInstance}} date-before-error-{{filterInstance}}">
+        <div class="govuk-form-group" id="{{dspFilterNames.updatedBefore}}-group-{{filterInstance}}">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="{{dspFilterNames.updatedBefore}}-hint-{{filterInstance}} {{dspFilterNames.updatedBefore}}-error-{{filterInstance}}">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated Before
             </legend>
-            <div id="date-before-hint-{{filterInstance}}" class="govuk-hint">
+            <div id="{{dspFilterNames.updatedBefore}}-hint-{{filterInstance}}" class="govuk-hint">
               For example, 2004
             </div>
-            <p id="date-before-error-{{filterInstance}}" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-before-error-message-{{filterInstance}}"></span>
+            <p id="{{dspFilterNames.updatedBefore}}-error-{{filterInstance}}" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="{{dspFilterNames.updatedBefore}}-error-message-{{filterInstance}}"></span>
             </p>
-            <div class="govuk-date-input" id="date-before-{{filterInstance}}">
+            <div class="govuk-date-input" id="{{dspFilterNames.updatedBefore}}-{{filterInstance}}">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-before-{{filterInstance}}-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-{{dspFilterNames.updatedBefore}}-{{filterInstance}}">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-before-{{filterInstance}}-year" name="before-year" type="text" value="{{dspFilterOptions.lastUpdated.beforeYear}}" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-{{dspFilterNames.updatedBefore}}-{{filterInstance}}" name="{{dspFilterNames.updatedBefore}}" type="text" value="{{dspFilterOptions.lastUpdated.beforeYear}}" inputmode="numeric">
                 </div>
               </div>
             </div>
           </fieldset>
         </div>
 
-        <div class="govuk-form-group" id="date-after-group-{{filterInstance}}">
-          <fieldset class="govuk-fieldset" role="group" aria-describedby="date-after-hint-{{filterInstance}} date-after-error-{{filterInstance}}">
+        <div class="govuk-form-group" id="{{dspFilterNames.updatedAfter}}-group-{{filterInstance}}">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="{{dspFilterNames.updatedAfter}}-hint-{{filterInstance}} {{dspFilterNames.updatedAfter}}-error-{{filterInstance}}">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Updated After
             </legend>
-            <div id="date-after-hint-{{filterInstance}}" class="govuk-hint">
+            <div id="{{dspFilterNames.updatedAfter}}-hint-{{filterInstance}}" class="govuk-hint">
               For example, 2015
             </div>
-            <p id="date-after-error-{{filterInstance}}" class="govuk-error-message display-none">
-              <span class="govuk-visually-hidden">Error:</span><span id="date-after-error-message-{{filterInstance}}"></span>
+            <p id="{{dspFilterNames.updatedAfter}}-error-{{filterInstance}}" class="govuk-error-message display-none">
+              <span class="govuk-visually-hidden">Error:</span><span id="{{dspFilterNames.updatedAfter}}-error-message-{{filterInstance}}"></span>
             </p>
-            <div class="govuk-date-input" id="date-after-{{filterInstance}}">
+            <div class="govuk-date-input" id="{{dspFilterNames.updatedAfter}}-{{filterInstance}}">
               <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                  <label class="govuk-label govuk-date-input__label" for="date-after-{{filterInstance}}-year">
+                  <label class="govuk-label govuk-date-input__label" for="filters-{{dspFilterNames.updatedAfter}}-{{filterInstance}}">
                     Year
                   </label>
-                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-after-{{filterInstance}}-year" name="after-year" type="text" value="{{dspFilterOptions.lastUpdated.afterYear}}" inputmode="numeric">
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="filters-{{dspFilterNames.updatedAfter}}-{{filterInstance}}" name="{{dspFilterNames.updatedAfter}}" type="text" value="{{dspFilterOptions.lastUpdated.afterYear}}" inputmode="numeric">
                 </div>
               </div>
             </div>
@@ -126,34 +126,34 @@
       </div>
     </div>
     <div class="filter-options__container">
-      <label for="filters-licence-accordion-toggle-{{filterInstance}}" class="filter-options__accordion" data-category-{{filterInstance}}="licence">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-licence-accordion-toggle-{{filterInstance}}" class="filter-options__accordion-toggle">
-          <svg id="filters-licence-accordion-icon-{{filterInstance}}" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters-{{dspFilterNames.licence}}-accordion-toggle-{{filterInstance}}" class="filter-options__accordion" data-category-{{filterInstance}}="licence">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters-{{dspFilterNames.licence}}-accordion-toggle-{{filterInstance}}" class="filter-options__accordion-toggle">
+          <svg id="filters-{{dspFilterNames.licence}}-accordion-icon-{{filterInstance}}" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Licence
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-licence-filters-{{filterInstance}}">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-{{dspFilterNames.licence}}-filters-{{filterInstance}}">
         {{ govukInput({
-          id: "licence-"+filterInstance,
+          id: "filters-"+dspFilterNames.licence+"-"+filterInstance,
           name: dspFilterNames.licence,
           value: dspFilterOptions.license
         }) }}
       </div>
     </div>
     <div class="filter-options__container filter-options__keyword-filter">
-      <label for="filters-keywords-accordion-toggle-{{filterInstance}}" class="filter-options__accordion" data-category-{{filterInstance}}="keywords">
-        <button type="button" aria-expanded="false" data-expanded="false" id="filters-keywords-accordion-toggle-{{filterInstance}}" class="filter-options__accordion-toggle">
-          <svg id="filters-keywords-accordion-icon-{{filterInstance}}" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
+      <label for="filters-{{dspFilterNames.keywords}}-accordion-toggle-{{filterInstance}}" class="filter-options__accordion" data-category-{{filterInstance}}="keywords">
+        <button type="button" aria-expanded="false" data-expanded="false" id="filters-{{dspFilterNames.keywords}}-accordion-toggle-{{filterInstance}}" class="filter-options__accordion-toggle">
+          <svg id="filters-{{dspFilterNames.keywords}}-accordion-icon-{{filterInstance}}" stroke="currentColor" fill="currentColor" viewBox="0 0 512 512" height="20px" width="20px" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="m112 328 144-144 144 144"></path></svg>
           <h3 class="filter-options__category-heading govuk-body-m">
             Keywords
           </h3>
         </button>
       </label>
-      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-keywords-filters-{{filterInstance}}">
+      <div class="filter-options__filters--hidden filter-options__accordion-child" id="filters-{{dspFilterNames.keywords}}-filters-{{filterInstance}}">
         {{ govukInput({
-          id: "keywords-"+filterInstance,
+          id: "filters-"+dspFilterNames.keywords+"-"+filterInstance,
           name: dspFilterNames.keywords
         }) }}
       </div>
@@ -165,8 +165,8 @@
 
     <div class="govuk-checkboxes govuk-checkboxes--small">
       <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-        <input class="govuk-checkboxes__input" id="retired-archived-{{filterInstance}}" {% if dspFilterOptions.retiredAndArchived %}checked{% endif %} name="{{dspFilterNames.retiredAndArchived}}" type="checkbox" value="true">
-        <label class="govuk-label govuk-checkboxes__label" for="retired-archived-{{filterInstance}}">
+        <input class="govuk-checkboxes__input" id="filters-{{dspFilterNames.retiredAndArchived}}-{{filterInstance}}" {% if dspFilterOptions.retiredAndArchived %}checked{% endif %} name="{{dspFilterNames.retiredAndArchived}}" type="checkbox" value="true">
+        <label class="govuk-label govuk-checkboxes__label" for="filters-{{dspFilterNames.retiredAndArchived}}-{{filterInstance}}">
           <span class="filter-options__retired-label">Include Retired & Archived records</span>
         </label>
       </div>

--- a/src/views/partials/results/summary.njk
+++ b/src/views/partials/results/summary.njk
@@ -10,6 +10,9 @@
     {{ searchResults.total }} results{% if not searchResults.total %} found
     {% endif %}
   </h2>
+  <div class="badge-container">
+    {% include 'partials/results/badges.njk' %}
+  </div>
   <div class="govuk-section-break--visible"></div>
   {% if not hasError %}
     <div class='map-container disabled' id="map-container">

--- a/src/views/screens/results/template.njk
+++ b/src/views/screens/results/template.njk
@@ -54,6 +54,7 @@
     </script>
     <script type="module" src="{{ assetPath }}/scripts/location.js"></script>
     <script type="module" src="{{ assetPath }}/scripts/filters.js"></script>
+    <script type="module" src="{{ assetPath }}/scripts/badges.js"></script>
     <script type="module" src="{{ assetPath }}/scripts/details.js"></script>
     <script type="module" src="{{ assetPath }}/scripts/keywordsFilter.js"></script>
     <script src="{{ assetPath }}/scripts/jquery.js"></script>


### PR DESCRIPTION
In the DSP core platform, when a filter is applied a badge is shown above the search results indicating what filters are currently active. These badges can be clicked on, which, if done, will disable the respective filter and remove the badge.

I have implemented this badge system. The difference between this and DSP is that the badges only show once the filters have been applied, which was the desired behaviour over DSP where they show up the moment a filter is selected.
If you click on one of the badges, it will reset the filter that corresponds to the badge, but you must apply the filters again to have the results changed.
The badges have the same styling as the DSP equivalents.

## To test
Modify any number of filters, then apply. The page should reload and badges should show up for all applied filters. Clicking any of these badges will remove the bade, and reset the filter. For example, if you enter `ogl` into the licence, apply, then click the badge, the input box should now be empty.

## Things to note
I also adjusted the IDs of all of the filter inputs as the badges relied on all inputs having consistently formatted IDs which was not the case. I also updated the IDs to be constructed from an object that was already passed that contains the names of the filters, so by changing the object it can easily update the names of the filters.
A future change that would make this even better would be to somehow abstract the filters into a nunjucks macro which means the IDs are only ever defined in the macro which makes them very easy to change because as of now, each filter is duplicated which means if the ID format changes, every filter has to be updated. This macro could also generate some javascript that potentially injects a global object full of the formatted IDs, so everything gets the same IDs all coming from a single source.

On a similar note to the IDs, in order to avoid duplicating SVG icons I created a basic nunjucks macro that takes the name of an icon, and an object that represents attribute, and returns the icon given that name with those inserted attributes. This makes use of nunjucks `include` being able to take an expression, so it is very easy to dynamically import files. Adding a new icon is just a case of adding a new nunjucks file into `src/views/macros/icons/`, making the name of the file be whatever the icon should be called. The `<svg>` tag should also contain `{{keys}}` within the attributes the user-provided attributes are inserted into the SVG correctly (see `src/views/macros/icons/cross.njk` for an example.)
This system could easily be extend for components that aren't just icons either.