### PR TITLE
feat(frontend): Display message when filters have been removed due to…

### DIFF
--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34119%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46761%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Details route template Document details with data Check status code and
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33823%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33013%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1582,7 +1582,7 @@ exports[`Details route template Document details with partial data Check status 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39619%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34673%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43927%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36065%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38785%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41549%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -252,6 +252,7 @@ exports[`Results block template Guided search journey Search results with empty 
         <main class="govuk-main-wrapper app-main-class" id="main-content">
           
     <h1 class="govuk-heading-l ">Search results</h1>
+    
     <div class="govuk-grid-row govuk-!-text-align-right">
       
   
@@ -322,7 +323,7 @@ exports[`Results block template Guided search journey Search results with empty 
     </div>
     <div class="filter-view-block-container">
       <div class="filter-view-block govuk-!-padding-4">
-        <h2 class='govuk-heading-m'>
+        <h2 class='govuk-heading-m filter-heading'>
           Key and filters
         </h2>
         <div class="govuk-section-break--visible"></div>
@@ -372,7 +373,7 @@ exports[`Results block template Guided search journey Search results with empty 
 
         </div>
         <div id="defra-bounding-box-info" class="govuk-!-margin-bottom-2">Filter your results to reduce the number of bounding boxes</div>
-        <div class="govuk-section-break--visible"></div>
+
         <div data-search-results-url="/natural-capital-ecosystem-assessment/search"></div>
         <div id="map-filter-block" data-action="/natural-capital-ecosystem-assessment/map-filters" data-fetch-map-filters></div>
       </div>
@@ -441,21 +442,52 @@ exports[`Results block template Guided search journey Search results with empty 
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <div class="filters-heading">
-            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-              Filters
-            </h2>
-            <div class="filters-buttons">
-              <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=&amp;rpp=20&amp;srt=most_relevant&amp;jry=gs&amp;pg=1&amp;scope=all">
-                Clear Filters
-              </button>
-              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
-                Apply Filters
-              </button>
-            </div>
-          </div>
-          <div class="govuk-section-break--visible"></div>
-          
+          <section>
+  <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+    Data Scope
+  </h2>
+  <div class="govuk-section-break--visible"></div>
+  <form class="govuk-form-group filter-options__ncea-only" id="scope-form-search_results">
+  <fieldset class="govuk-fieldset">
+    <legend class="filter-options__legend">
+      <h3>Data Scope Filter </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
+        <label class="govuk-label govuk-radios__label" for="scope-search_results">
+          NCEA Metadata Only
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
+        <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
+          DSP and NCEA Metadata
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</form>
+</section>
+
+<section>  
+  <div class="filters-heading">
+    <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+      Filters
+    </h2>
+    
+      <div class="filters-buttons">
+        <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=&amp;rpp=20&amp;srt=most_relevant&amp;jry=gs&amp;pg=1&amp;scope=all">
+          Clear Filters
+        </button>
+        <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+          Apply Filters
+        </button>
+      </div>
+    
+  </div>
+  <div class="govuk-section-break--visible"></div>
+  
 
 
 
@@ -488,28 +520,6 @@ exports[`Results block template Guided search journey Search results with empty 
 
 <form autocomplete="off" id="filters-search_results">
   <section>
-    <div class="govuk-form-group filter-options__ncea-only">
-      <fieldset class="govuk-fieldset">
-        <legend class="filter-options__legend">
-          <h3>Data Scope Filter </h3>
-        </legend>
-        <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
-            <label class="govuk-label govuk-radios__label" for="scope-search_results">
-              NCEA Metadata Only
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
-            <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-              DSP and NCEA Metadata
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
     <div>
       
         <div class="filter-options__container">
@@ -539,77 +549,77 @@ exports[`Results block template Guided search journey Search results with empty 
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
@@ -834,569 +844,569 @@ exports[`Results block template Guided search journey Search results with empty 
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
-                      Comma Separate Values file (CSV)
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Comma Separated Values file (CSV)-search_results" name="fmt" type="checkbox" value="Open format | Comma Separated Values file (CSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Comma Separated Values file (CSV)-search_results">
+                      Comma Separated Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOCX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI, Intergraph, MS Access (MDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
-                      Shapefile
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Shapefile (SHP)-search_results" name="fmt" type="checkbox" value="Open format | Shapefile (SHP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Shapefile (SHP)-search_results">
+                      Shapefile (SHP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
-                      Plain Text File
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Plain Text File (TXT)-search_results" name="fmt" type="checkbox" value="Open Format | Plain Text File (TXT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Plain Text File (TXT)-search_results">
+                      Plain Text File (TXT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
-                      MS Excel (XLS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MS Excel (XLSX)-search_results" name="fmt" type="checkbox" value="Open format | MS Excel (XLSX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MS Excel (XLSX)-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | Access 2007 onwards database (ACCDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results" name="fmt" type="checkbox" value="Proprietary Format | Arc/Info Binary Grid (AIG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results" name="fmt" type="checkbox" value="Open format | Arc/Info ASCII Grid (AAIGrid)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Gridded XYZ (XYZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results" name="fmt" type="checkbox" value="Open Format | Bathymetric Attributed Grid (BAG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | CAD Data eXchange Format (DXF)-search_results" name="fmt" type="checkbox" value="Open format | CAD Data eXchange Format (DXF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | CAD Data eXchange Format (DXF)-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | CAD Drawing file (DWG)-search_results" name="fmt" type="checkbox" value="Proprietary format | CAD Drawing file (DWG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | CAD Drawing file (DWG)-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results" name="fmt" type="checkbox" value="OGC Web Services | Catalogue Service for the Web (CSW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (Citygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (Citygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (Citygml)-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | dBASE (DBF)-search_results" name="fmt" type="checkbox" value="Open format | dBASE (DBF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | dBASE (DBF)-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ER Mapper (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ER Mapper (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ER Mapper (ECW)-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDAS IMAGINE (IMG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDASRaw (RAW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDASRaw (RAW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDASRaw (RAW)-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Generic Sensor Format (ALL)-search_results" name="fmt" type="checkbox" value="Proprietary format | Generic Sensor Format (ALL)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Generic Sensor Format (ALL)-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | Graphical Interchange Format (GIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results" name="fmt" type="checkbox" value="Open format | Geo Tagged Image File Format (GeoTIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geography Markup Language (GML)-search_results" name="fmt" type="checkbox" value="Open format | Geography Markup Language (GML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geography Markup Language (GML)-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoPackage (GPKG)-search_results" name="fmt" type="checkbox" value="Open format | GeoPackage (GPKG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoPackage (GPKG)-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoRSS (Geo)-search_results" name="fmt" type="checkbox" value="Open format | GeoRSS (Geo)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoRSS (Geo)-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GPS Exchange Format (GPX)-search_results" name="fmt" type="checkbox" value="Open format | GPS Exchange Format (GPX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GPS Exchange Format (GPX)-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data (SD)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data (SD)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data (SD)-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data scene (SCENE)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results" name="fmt" type="checkbox" value="Open format | JavaScript Object Notation (GeoJSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results" name="fmt" type="checkbox" value="OGC Web Services | JavaScript Object Notation (JSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group (JPEG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group 2000 (JPEG2000)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language (KML)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language (KML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language (KML)-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language Zipped (KMZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAS)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAS)-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Lemuel-Ziv and Welch (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
-                      Many DAT formats (DAT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Many XML formats (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
-                      MapInfo (TAB)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
-                      MapInfo MIF/MID (MIF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
-                      Microsoft Office Pipe Separated Values file format (PSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
-                      Multi-resolution Seamless Image Database (MrSID)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
-                      National Transfer Format - OS (NTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
-                      Open Document Presentation (ODP)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
-                      Open Document Spreadsheet (ODS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
-                      Open Document Text (ODT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
-                      Outlook File Template (OFT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Packbit (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - 3D (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - GeoReferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Standardized (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Unreferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
-                      Portable Network Graphic (PNG)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
-                      Resource Description Framework (RDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Resource Description Framework (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
-                      Rich Text Format (RTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
-                      Tab Separated Values (TSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Tagged Image File Format (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Lempel-Ziv and Welch (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many DAT formats (DAT)-search_results" name="fmt" type="checkbox" value="Open format | Many DAT formats (DAT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many DAT formats (DAT)-search_results">
+                      Many DAT formats (DAT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many XML formats (XML)-search_results" name="fmt" type="checkbox" value="Open format | Many XML formats (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many XML formats (XML)-search_results">
+                      Many XML formats (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo (TAB)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo (TAB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo (TAB)-search_results">
+                      MapInfo (TAB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo MIF/MID (MIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results">
+                      MapInfo MIF/MID (MIF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results" name="fmt" type="checkbox" value="Open format | Microsoft Office Pipe Separated Values file format (PSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results">
+                      Microsoft Office Pipe Separated Values file format (PSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results" name="fmt" type="checkbox" value="Compressed format | Multi-resolution Seamless Image Database (MrSID)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results">
+                      Multi-resolution Seamless Image Database (MrSID)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | National Transfer Format - OS (NTF)-search_results" name="fmt" type="checkbox" value="Open format | National Transfer Format - OS (NTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | National Transfer Format - OS (NTF)-search_results">
+                      National Transfer Format - OS (NTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Presentation (ODP)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Presentation (ODP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Presentation (ODP)-search_results">
+                      Open Document Presentation (ODP)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Spreadsheet (ODS)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Spreadsheet (ODS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Spreadsheet (ODS)-search_results">
+                      Open Document Spreadsheet (ODS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Text (ODT)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Text (ODT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Text (ODT)-search_results">
+                      Open Document Text (ODT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Outlook File Template (OFT)-search_results" name="fmt" type="checkbox" value="Proprietary format | Outlook File Template (OFT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Outlook File Template (OFT)-search_results">
+                      Outlook File Template (OFT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Packbit (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Packbit (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Packbit (TIFF)-search_results">
+                      Packbit (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - 3D (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - 3D (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - 3D (PDF)-search_results">
+                      Portable Document Format - 3D (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - GeoReferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results">
+                      Portable Document Format - GeoReferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Standardized (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Standardized (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Standardized (PDF)-search_results">
+                      Portable Document Format - Standardized (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Unreferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results">
+                      Portable Document Format - Unreferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Network Graphic (PNG)-search_results" name="fmt" type="checkbox" value="Open format | Portable Network Graphic (PNG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Network Graphic (PNG)-search_results">
+                      Portable Network Graphic (PNG)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (RDF)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (RDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (RDF)-search_results">
+                      Resource Description Framework (RDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (XML)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (XML)-search_results">
+                      Resource Description Framework (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Rich Text Format (RTF)-search_results" name="fmt" type="checkbox" value="Open format | Rich Text Format (RTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Rich Text Format (RTF)-search_results">
+                      Rich Text Format (RTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Tab Separated Values (TSV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Tab Separated Values (TSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Tab Separated Values (TSV)-search_results">
+                      Tab Separated Values (TSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Tagged Image File Format (TIFF)-search_results" name="fmt" type="checkbox" value="Open format | Tagged Image File Format (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Tagged Image File Format (TIFF)-search_results">
+                      Tagged Image File Format (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Apache Parquet (PARQUET)-search_results" name="fmt" type="checkbox" value="Open format | Apache Parquet (PARQUET)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Apache Parquet (PARQUET)-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
-                      City GML (CiCompressedtygml)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results" name="fmt" type="checkbox" value="Open format | FASTQ Biological Sequence File (FASTQ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results" name="fmt" type="checkbox" value="Open format | FASTA Biological Sequence File (FASTA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results" name="fmt" type="checkbox" value="Open format | Free Lossless Audio Codec (FLAC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results" name="fmt" type="checkbox" value="Open format | MPEG Audio Layer 3 (MP3)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | R Script File (R)-search_results" name="fmt" type="checkbox" value="Open format | R Script File (R)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | R Script File (R)-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Audio Video Interleave (AVI)-search_results" name="fmt" type="checkbox" value="Proprietary format | Audio Video Interleave (AVI)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Audio Video Interleave (AVI)-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | Enhanced Compression Wavelet (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYR)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYR)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYR)-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYRX)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYRX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYRX)-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results" name="fmt" type="checkbox" value="Proprietary format | MPEG-4 Video file (MP4)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | QuickTime File Format (MOV)-search_results" name="fmt" type="checkbox" value="Proprietary format | QuickTime File Format (MOV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | QuickTime File Format (MOV)-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Waveform Audio File Format (WAV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | QIIME Zipped Artifact (QZA)-search_results" name="fmt" type="checkbox" value="Open format | QIIME Zipped Artifact (QZA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | QIIME Zipped Artifact (QZA)-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Biological Observation Matrix (BIOM)-search_results" name="fmt" type="checkbox" value="Open format | Biological Observation Matrix (BIOM)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Biological Observation Matrix (BIOM)-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GNU zip archive (GZIP)-search_results" name="fmt" type="checkbox" value="Open format | GNU zip archive (GZIP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GNU zip archive (GZIP)-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Compressed tape archive (TAR.GZ)-search_results" name="fmt" type="checkbox" value="Open format | Compressed tape archive (TAR.GZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Compressed tape archive (TAR.GZ)-search_results">
                       Compressed tape archive (TAR.GZ)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI File based Geodatabase (GDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results">
+                      ESRI File based Geodatabase (GDB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Excel (XLS)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Excel (XLS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Excel (XLS)-search_results">
+                      MS Excel (XLS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (CiCompressedtygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (CiCompressedtygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (CiCompressedtygml)-search_results">
+                      City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
@@ -1556,8 +1566,8 @@ exports[`Results block template Guided search journey Search results with empty 
 
 </div>
 
-            
-          <div class="filter-options__keyboard-filter-content">
+
+          <div class="filter-options__keyboard-filter-content-search_results">
               <ul class="filter-options__keyboard-filter-list" id="keyboard-filter-list">
               </ul>
           </div>
@@ -1579,6 +1589,7 @@ exports[`Results block template Guided search journey Search results with empty 
     </div>
   </section>
 </form>
+</section>
         </div>
         <div class="govuk-grid-column-two-thirds">
           
@@ -2242,7 +2253,7 @@ exports[`Results block template Guided search journey Search results with error 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34627%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33801%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2274,6 +2285,7 @@ exports[`Results block template Guided search journey Search results with error 
         <main class="govuk-main-wrapper app-main-class" id="main-content">
           
     <h1 class="govuk-heading-l ">Search results</h1>
+    
     <div class="govuk-grid-row govuk-!-text-align-right">
       
   
@@ -2344,7 +2356,7 @@ exports[`Results block template Guided search journey Search results with error 
     </div>
     <div class="filter-view-block-container">
       <div class="filter-view-block govuk-!-padding-4">
-        <h2 class='govuk-heading-m'>
+        <h2 class='govuk-heading-m filter-heading'>
           Key and filters
         </h2>
         <div class="govuk-section-break--visible"></div>
@@ -2394,7 +2406,7 @@ exports[`Results block template Guided search journey Search results with error 
 
         </div>
         <div id="defra-bounding-box-info" class="govuk-!-margin-bottom-2">Filter your results to reduce the number of bounding boxes</div>
-        <div class="govuk-section-break--visible"></div>
+
         <div data-search-results-url="/natural-capital-ecosystem-assessment/search"></div>
         <div id="map-filter-block" data-action="/natural-capital-ecosystem-assessment/map-filters" data-fetch-map-filters></div>
       </div>
@@ -2463,21 +2475,43 @@ exports[`Results block template Guided search journey Search results with error 
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <div class="filters-heading">
-            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-              Filters
-            </h2>
-            <div class="filters-buttons">
-              <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-" id="filters-reset-" data-reset-url="">
-                Clear Filters
-              </button>
-              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-">
-                Apply Filters
-              </button>
-            </div>
-          </div>
-          <div class="govuk-section-break--visible"></div>
-          
+          <section>
+  <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+    Data Scope
+  </h2>
+  <div class="govuk-section-break--visible"></div>
+  <form class="govuk-form-group filter-options__ncea-only" id="scope-form-">
+  <fieldset class="govuk-fieldset">
+    <legend class="filter-options__legend">
+      <h3>Data Scope Filter </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="scope-">
+          NCEA Metadata Only
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="scope-all-">
+          DSP and NCEA Metadata
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</form>
+</section>
+
+<section>  
+  <div class="filters-heading">
+    <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+      Filters
+    </h2>
+    
+  </div>
+  <div class="govuk-section-break--visible"></div>
+  
 
 
 
@@ -2510,28 +2544,6 @@ exports[`Results block template Guided search journey Search results with error 
 
 <form autocomplete="off" id="filters-">
   <section>
-    <div class="govuk-form-group filter-options__ncea-only">
-      <fieldset class="govuk-fieldset">
-        <legend class="filter-options__legend">
-          <h3>Data Scope Filter </h3>
-        </legend>
-        <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="scope-">
-              NCEA Metadata Only
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="scope-all-">
-              DSP and NCEA Metadata
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
     <div>
       
     </div>
@@ -2684,8 +2696,8 @@ exports[`Results block template Guided search journey Search results with error 
 
 </div>
 
-            
-          <div class="filter-options__keyboard-filter-content">
+
+          <div class="filter-options__keyboard-filter-content-">
               <ul class="filter-options__keyboard-filter-list" id="keyboard-filter-list">
               </ul>
           </div>
@@ -2707,6 +2719,7 @@ exports[`Results block template Guided search journey Search results with error 
     </div>
   </section>
 </form>
+</section>
         </div>
         <div class="govuk-grid-column-two-thirds">
           
@@ -3072,7 +3085,7 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45119%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40031%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -3104,6 +3117,7 @@ exports[`Results block template Quick search journey Search results with data sh
         <main class="govuk-main-wrapper app-main-class" id="main-content">
           
     <h1 class="govuk-heading-l ">Search results</h1>
+    
     <div class="govuk-grid-row govuk-!-text-align-right">
       
   
@@ -3174,7 +3188,7 @@ exports[`Results block template Quick search journey Search results with data sh
     </div>
     <div class="filter-view-block-container">
       <div class="filter-view-block govuk-!-padding-4">
-        <h2 class='govuk-heading-m'>
+        <h2 class='govuk-heading-m filter-heading'>
           Key and filters
         </h2>
         <div class="govuk-section-break--visible"></div>
@@ -3224,7 +3238,7 @@ exports[`Results block template Quick search journey Search results with data sh
 
         </div>
         <div id="defra-bounding-box-info" class="govuk-!-margin-bottom-2">Filter your results to reduce the number of bounding boxes</div>
-        <div class="govuk-section-break--visible"></div>
+
         <div data-search-results-url="/natural-capital-ecosystem-assessment/search"></div>
         <div id="map-filter-block" data-action="/natural-capital-ecosystem-assessment/map-filters" data-fetch-map-filters></div>
       </div>
@@ -3293,21 +3307,52 @@ exports[`Results block template Quick search journey Search results with data sh
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <div class="filters-heading">
-            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-              Filters
-            </h2>
-            <div class="filters-buttons">
-              <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
-                Clear Filters
-              </button>
-              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
-                Apply Filters
-              </button>
-            </div>
-          </div>
-          <div class="govuk-section-break--visible"></div>
-          
+          <section>
+  <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+    Data Scope
+  </h2>
+  <div class="govuk-section-break--visible"></div>
+  <form class="govuk-form-group filter-options__ncea-only" id="scope-form-search_results">
+  <fieldset class="govuk-fieldset">
+    <legend class="filter-options__legend">
+      <h3>Data Scope Filter </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
+        <label class="govuk-label govuk-radios__label" for="scope-search_results">
+          NCEA Metadata Only
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
+        <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
+          DSP and NCEA Metadata
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</form>
+</section>
+
+<section>  
+  <div class="filters-heading">
+    <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+      Filters
+    </h2>
+    
+      <div class="filters-buttons">
+        <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
+          Clear Filters
+        </button>
+        <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+          Apply Filters
+        </button>
+      </div>
+    
+  </div>
+  <div class="govuk-section-break--visible"></div>
+  
 
 
 
@@ -3340,28 +3385,6 @@ exports[`Results block template Quick search journey Search results with data sh
 
 <form autocomplete="off" id="filters-search_results">
   <section>
-    <div class="govuk-form-group filter-options__ncea-only">
-      <fieldset class="govuk-fieldset">
-        <legend class="filter-options__legend">
-          <h3>Data Scope Filter </h3>
-        </legend>
-        <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
-            <label class="govuk-label govuk-radios__label" for="scope-search_results">
-              NCEA Metadata Only
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
-            <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-              DSP and NCEA Metadata
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
     <div>
       
         <div class="filter-options__container">
@@ -3391,77 +3414,77 @@ exports[`Results block template Quick search journey Search results with data sh
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
@@ -3686,569 +3709,569 @@ exports[`Results block template Quick search journey Search results with data sh
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
-                      Comma Separate Values file (CSV)
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Comma Separated Values file (CSV)-search_results" name="fmt" type="checkbox" value="Open format | Comma Separated Values file (CSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Comma Separated Values file (CSV)-search_results">
+                      Comma Separated Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOCX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI, Intergraph, MS Access (MDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
-                      Shapefile
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Shapefile (SHP)-search_results" name="fmt" type="checkbox" value="Open format | Shapefile (SHP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Shapefile (SHP)-search_results">
+                      Shapefile (SHP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
-                      Plain Text File
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Plain Text File (TXT)-search_results" name="fmt" type="checkbox" value="Open Format | Plain Text File (TXT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Plain Text File (TXT)-search_results">
+                      Plain Text File (TXT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
-                      MS Excel (XLS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MS Excel (XLSX)-search_results" name="fmt" type="checkbox" value="Open format | MS Excel (XLSX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MS Excel (XLSX)-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | Access 2007 onwards database (ACCDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results" name="fmt" type="checkbox" value="Proprietary Format | Arc/Info Binary Grid (AIG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results" name="fmt" type="checkbox" value="Open format | Arc/Info ASCII Grid (AAIGrid)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Gridded XYZ (XYZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results" name="fmt" type="checkbox" value="Open Format | Bathymetric Attributed Grid (BAG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | CAD Data eXchange Format (DXF)-search_results" name="fmt" type="checkbox" value="Open format | CAD Data eXchange Format (DXF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | CAD Data eXchange Format (DXF)-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | CAD Drawing file (DWG)-search_results" name="fmt" type="checkbox" value="Proprietary format | CAD Drawing file (DWG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | CAD Drawing file (DWG)-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results" name="fmt" type="checkbox" value="OGC Web Services | Catalogue Service for the Web (CSW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (Citygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (Citygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (Citygml)-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | dBASE (DBF)-search_results" name="fmt" type="checkbox" value="Open format | dBASE (DBF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | dBASE (DBF)-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ER Mapper (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ER Mapper (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ER Mapper (ECW)-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDAS IMAGINE (IMG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDASRaw (RAW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDASRaw (RAW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDASRaw (RAW)-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Generic Sensor Format (ALL)-search_results" name="fmt" type="checkbox" value="Proprietary format | Generic Sensor Format (ALL)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Generic Sensor Format (ALL)-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | Graphical Interchange Format (GIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results" name="fmt" type="checkbox" value="Open format | Geo Tagged Image File Format (GeoTIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geography Markup Language (GML)-search_results" name="fmt" type="checkbox" value="Open format | Geography Markup Language (GML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geography Markup Language (GML)-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoPackage (GPKG)-search_results" name="fmt" type="checkbox" value="Open format | GeoPackage (GPKG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoPackage (GPKG)-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoRSS (Geo)-search_results" name="fmt" type="checkbox" value="Open format | GeoRSS (Geo)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoRSS (Geo)-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GPS Exchange Format (GPX)-search_results" name="fmt" type="checkbox" value="Open format | GPS Exchange Format (GPX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GPS Exchange Format (GPX)-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data (SD)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data (SD)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data (SD)-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data scene (SCENE)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results" name="fmt" type="checkbox" value="Open format | JavaScript Object Notation (GeoJSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results" name="fmt" type="checkbox" value="OGC Web Services | JavaScript Object Notation (JSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group (JPEG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group 2000 (JPEG2000)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language (KML)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language (KML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language (KML)-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language Zipped (KMZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAS)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAS)-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Lemuel-Ziv and Welch (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
-                      Many DAT formats (DAT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Many XML formats (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
-                      MapInfo (TAB)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
-                      MapInfo MIF/MID (MIF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
-                      Microsoft Office Pipe Separated Values file format (PSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
-                      Multi-resolution Seamless Image Database (MrSID)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
-                      National Transfer Format - OS (NTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
-                      Open Document Presentation (ODP)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
-                      Open Document Spreadsheet (ODS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
-                      Open Document Text (ODT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
-                      Outlook File Template (OFT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Packbit (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - 3D (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - GeoReferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Standardized (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Unreferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
-                      Portable Network Graphic (PNG)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
-                      Resource Description Framework (RDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Resource Description Framework (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
-                      Rich Text Format (RTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
-                      Tab Separated Values (TSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Tagged Image File Format (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Lempel-Ziv and Welch (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many DAT formats (DAT)-search_results" name="fmt" type="checkbox" value="Open format | Many DAT formats (DAT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many DAT formats (DAT)-search_results">
+                      Many DAT formats (DAT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many XML formats (XML)-search_results" name="fmt" type="checkbox" value="Open format | Many XML formats (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many XML formats (XML)-search_results">
+                      Many XML formats (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo (TAB)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo (TAB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo (TAB)-search_results">
+                      MapInfo (TAB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo MIF/MID (MIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results">
+                      MapInfo MIF/MID (MIF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results" name="fmt" type="checkbox" value="Open format | Microsoft Office Pipe Separated Values file format (PSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results">
+                      Microsoft Office Pipe Separated Values file format (PSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results" name="fmt" type="checkbox" value="Compressed format | Multi-resolution Seamless Image Database (MrSID)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results">
+                      Multi-resolution Seamless Image Database (MrSID)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | National Transfer Format - OS (NTF)-search_results" name="fmt" type="checkbox" value="Open format | National Transfer Format - OS (NTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | National Transfer Format - OS (NTF)-search_results">
+                      National Transfer Format - OS (NTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Presentation (ODP)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Presentation (ODP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Presentation (ODP)-search_results">
+                      Open Document Presentation (ODP)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Spreadsheet (ODS)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Spreadsheet (ODS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Spreadsheet (ODS)-search_results">
+                      Open Document Spreadsheet (ODS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Text (ODT)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Text (ODT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Text (ODT)-search_results">
+                      Open Document Text (ODT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Outlook File Template (OFT)-search_results" name="fmt" type="checkbox" value="Proprietary format | Outlook File Template (OFT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Outlook File Template (OFT)-search_results">
+                      Outlook File Template (OFT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Packbit (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Packbit (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Packbit (TIFF)-search_results">
+                      Packbit (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - 3D (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - 3D (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - 3D (PDF)-search_results">
+                      Portable Document Format - 3D (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - GeoReferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results">
+                      Portable Document Format - GeoReferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Standardized (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Standardized (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Standardized (PDF)-search_results">
+                      Portable Document Format - Standardized (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Unreferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results">
+                      Portable Document Format - Unreferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Network Graphic (PNG)-search_results" name="fmt" type="checkbox" value="Open format | Portable Network Graphic (PNG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Network Graphic (PNG)-search_results">
+                      Portable Network Graphic (PNG)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (RDF)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (RDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (RDF)-search_results">
+                      Resource Description Framework (RDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (XML)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (XML)-search_results">
+                      Resource Description Framework (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Rich Text Format (RTF)-search_results" name="fmt" type="checkbox" value="Open format | Rich Text Format (RTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Rich Text Format (RTF)-search_results">
+                      Rich Text Format (RTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Tab Separated Values (TSV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Tab Separated Values (TSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Tab Separated Values (TSV)-search_results">
+                      Tab Separated Values (TSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Tagged Image File Format (TIFF)-search_results" name="fmt" type="checkbox" value="Open format | Tagged Image File Format (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Tagged Image File Format (TIFF)-search_results">
+                      Tagged Image File Format (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Apache Parquet (PARQUET)-search_results" name="fmt" type="checkbox" value="Open format | Apache Parquet (PARQUET)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Apache Parquet (PARQUET)-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
-                      City GML (CiCompressedtygml)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results" name="fmt" type="checkbox" value="Open format | FASTQ Biological Sequence File (FASTQ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results" name="fmt" type="checkbox" value="Open format | FASTA Biological Sequence File (FASTA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results" name="fmt" type="checkbox" value="Open format | Free Lossless Audio Codec (FLAC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results" name="fmt" type="checkbox" value="Open format | MPEG Audio Layer 3 (MP3)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | R Script File (R)-search_results" name="fmt" type="checkbox" value="Open format | R Script File (R)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | R Script File (R)-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Audio Video Interleave (AVI)-search_results" name="fmt" type="checkbox" value="Proprietary format | Audio Video Interleave (AVI)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Audio Video Interleave (AVI)-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | Enhanced Compression Wavelet (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYR)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYR)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYR)-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYRX)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYRX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYRX)-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results" name="fmt" type="checkbox" value="Proprietary format | MPEG-4 Video file (MP4)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | QuickTime File Format (MOV)-search_results" name="fmt" type="checkbox" value="Proprietary format | QuickTime File Format (MOV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | QuickTime File Format (MOV)-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Waveform Audio File Format (WAV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | QIIME Zipped Artifact (QZA)-search_results" name="fmt" type="checkbox" value="Open format | QIIME Zipped Artifact (QZA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | QIIME Zipped Artifact (QZA)-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Biological Observation Matrix (BIOM)-search_results" name="fmt" type="checkbox" value="Open format | Biological Observation Matrix (BIOM)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Biological Observation Matrix (BIOM)-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GNU zip archive (GZIP)-search_results" name="fmt" type="checkbox" value="Open format | GNU zip archive (GZIP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GNU zip archive (GZIP)-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Compressed tape archive (TAR.GZ)-search_results" name="fmt" type="checkbox" value="Open format | Compressed tape archive (TAR.GZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Compressed tape archive (TAR.GZ)-search_results">
                       Compressed tape archive (TAR.GZ)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI File based Geodatabase (GDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results">
+                      ESRI File based Geodatabase (GDB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Excel (XLS)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Excel (XLS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Excel (XLS)-search_results">
+                      MS Excel (XLS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (CiCompressedtygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (CiCompressedtygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (CiCompressedtygml)-search_results">
+                      City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
@@ -4408,8 +4431,8 @@ exports[`Results block template Quick search journey Search results with data sh
 
 </div>
 
-            
-          <div class="filter-options__keyboard-filter-content">
+
+          <div class="filter-options__keyboard-filter-content-search_results">
               <ul class="filter-options__keyboard-filter-list" id="keyboard-filter-list">
               </ul>
           </div>
@@ -4431,6 +4454,7 @@ exports[`Results block template Quick search journey Search results with data sh
     </div>
   </section>
 </form>
+</section>
         </div>
         <div class="govuk-grid-column-two-thirds">
           
@@ -5342,7 +5366,7 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45777%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36643%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -5374,6 +5398,7 @@ exports[`Results block template Quick search journey Search results with empty d
         <main class="govuk-main-wrapper app-main-class" id="main-content">
           
     <h1 class="govuk-heading-l ">Search results</h1>
+    
     <div class="govuk-grid-row govuk-!-text-align-right">
       
   
@@ -5444,7 +5469,7 @@ exports[`Results block template Quick search journey Search results with empty d
     </div>
     <div class="filter-view-block-container">
       <div class="filter-view-block govuk-!-padding-4">
-        <h2 class='govuk-heading-m'>
+        <h2 class='govuk-heading-m filter-heading'>
           Key and filters
         </h2>
         <div class="govuk-section-break--visible"></div>
@@ -5494,7 +5519,7 @@ exports[`Results block template Quick search journey Search results with empty d
 
         </div>
         <div id="defra-bounding-box-info" class="govuk-!-margin-bottom-2">Filter your results to reduce the number of bounding boxes</div>
-        <div class="govuk-section-break--visible"></div>
+
         <div data-search-results-url="/natural-capital-ecosystem-assessment/search"></div>
         <div id="map-filter-block" data-action="/natural-capital-ecosystem-assessment/map-filters" data-fetch-map-filters></div>
       </div>
@@ -5563,21 +5588,52 @@ exports[`Results block template Quick search journey Search results with empty d
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <div class="filters-heading">
-            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-              Filters
-            </h2>
-            <div class="filters-buttons">
-              <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
-                Clear Filters
-              </button>
-              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
-                Apply Filters
-              </button>
-            </div>
-          </div>
-          <div class="govuk-section-break--visible"></div>
-          
+          <section>
+  <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+    Data Scope
+  </h2>
+  <div class="govuk-section-break--visible"></div>
+  <form class="govuk-form-group filter-options__ncea-only" id="scope-form-search_results">
+  <fieldset class="govuk-fieldset">
+    <legend class="filter-options__legend">
+      <h3>Data Scope Filter </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
+        <label class="govuk-label govuk-radios__label" for="scope-search_results">
+          NCEA Metadata Only
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
+        <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
+          DSP and NCEA Metadata
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</form>
+</section>
+
+<section>  
+  <div class="filters-heading">
+    <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+      Filters
+    </h2>
+    
+      <div class="filters-buttons">
+        <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-search_results" id="filters-reset-search_results" data-reset-url="/natural-capital-ecosystem-assessment/search?q=marine&amp;rpp=20&amp;srt=most_relevant&amp;jry=qs&amp;pg=1&amp;scope=all">
+          Clear Filters
+        </button>
+        <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-search_results">
+          Apply Filters
+        </button>
+      </div>
+    
+  </div>
+  <div class="govuk-section-break--visible"></div>
+  
 
 
 
@@ -5610,28 +5666,6 @@ exports[`Results block template Quick search journey Search results with empty d
 
 <form autocomplete="off" id="filters-search_results">
   <section>
-    <div class="govuk-form-group filter-options__ncea-only">
-      <fieldset class="govuk-fieldset">
-        <legend class="filter-options__legend">
-          <h3>Data Scope Filter </h3>
-        </legend>
-        <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
-            <label class="govuk-label govuk-radios__label" for="scope-search_results">
-              NCEA Metadata Only
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
-            <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-              DSP and NCEA Metadata
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
     <div>
       
         <div class="filter-options__container">
@@ -5661,77 +5695,77 @@ exports[`Results block template Quick search journey Search results with empty d
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-ahdb-search_results" name="org" type="checkbox" value="ahdb" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ahdb-search_results">
                       Agriculture &amp; Horticulture Development Board
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-apha-search_results" name="org" type="checkbox" value="apha" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-apha-search_results">
                       Animal &amp; Plant Health Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-cefas-search_results" name="org" type="checkbox" value="cefas" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-cefas-search_results">
                       Centre for Environment, Fisheries &amp; Aquaculture Science
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-defra-search_results" name="org" type="checkbox" value="defra" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-defra-search_results">
                       Department for Environment, Food &amp; Rural Affairs
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ea-search_results" name="org" type="checkbox" value="ea" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ea-search_results">
                       Environment Agency
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-fc-search_results" name="org" type="checkbox" value="fc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-fc-search_results">
                       Forestry Commission
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-jncc-search_results" name="org" type="checkbox" value="jncc" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-jncc-search_results">
                       Joint Nature Conservation Committee
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-kew-search_results" name="org" type="checkbox" value="kew" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-kew-search_results">
                       KEW
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-mmo-search_results" name="org" type="checkbox" value="mmo" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-mmo-search_results">
                       Marine Management Organisation
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="true">
+                    <input class="govuk-checkboxes__input"  id="filters-ne-search_results" name="org" type="checkbox" value="ne" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-ne-search_results">
                       Natural England
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="false">
+                    <input class="govuk-checkboxes__input"  id="filters-rpa-search_results" name="org" type="checkbox" value="rpa" data-multiple="true" data-ncea-only="">
                     <label class="govuk-label govuk-checkboxes__label" for="filters-rpa-search_results">
                       Rural Payments Agency
                     </label>
@@ -5956,569 +5990,569 @@ exports[`Results block template Quick search journey Search results with empty d
 
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csv-search_results" name="fmt" type="checkbox" value="csv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csv-search_results">
-                      Comma Separate Values file (CSV)
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Comma Separated Values file (CSV)-search_results" name="fmt" type="checkbox" value="Open format | Comma Separated Values file (CSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Comma Separated Values file (CSV)-search_results">
+                      Comma Separated Values file (CSV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-doc-search_results" name="fmt" type="checkbox" value="doc" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-doc-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOC)-search_results">
                       MS Word 2010 onwards document (DOC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-docx-search_results" name="fmt" type="checkbox" value="docx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-docx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Word 2010 onwards document (DOCX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Word 2010 onwards document (DOCX)-search_results">
                       MS Word 2010 onwards document (DOCX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mdb-search_results" name="fmt" type="checkbox" value="mdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI, Intergraph, MS Access (MDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI, Intergraph, MS Access (MDB)-search_results">
                       ESRI, Intergraph, MS Access (MDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-shp-search_results" name="fmt" type="checkbox" value="shp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-shp-search_results">
-                      Shapefile
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Shapefile (SHP)-search_results" name="fmt" type="checkbox" value="Open format | Shapefile (SHP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Shapefile (SHP)-search_results">
+                      Shapefile (SHP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-txt-search_results" name="fmt" type="checkbox" value="txt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-txt-search_results">
-                      Plain Text File
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Plain Text File (TXT)-search_results" name="fmt" type="checkbox" value="Open Format | Plain Text File (TXT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Plain Text File (TXT)-search_results">
+                      Plain Text File (TXT)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xls-search_results" name="fmt" type="checkbox" value="xls" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xls-search_results">
-                      MS Excel (XLS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xlsx-search_results" name="fmt" type="checkbox" value="xlsx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xlsx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MS Excel (XLSX)-search_results" name="fmt" type="checkbox" value="Open format | MS Excel (XLSX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MS Excel (XLSX)-search_results">
                       MS Excel (XLSX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-accdb-search_results" name="fmt" type="checkbox" value="accdb" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-accdb-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | Access 2007 onwards database (ACCDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Access 2007 onwards database (ACCDB)-search_results">
                       Access 2007 onwards database (ACCDB)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aig-search_results" name="fmt" type="checkbox" value="aig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results" name="fmt" type="checkbox" value="Proprietary Format | Arc/Info Binary Grid (AIG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary Format | Arc/Info Binary Grid (AIG)-search_results">
                       Arc/Info Binary Grid (AIG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-aaig-search_results" name="fmt" type="checkbox" value="aaig" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-aaig-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results" name="fmt" type="checkbox" value="Open format | Arc/Info ASCII Grid (AAIGrid)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Arc/Info ASCII Grid (AAIGrid)-search_results">
                       Arc/Info ASCII Grid (AAIGrid)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xyz-search_results" name="fmt" type="checkbox" value="xyz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xyz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Gridded XYZ (XYZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Gridded XYZ (XYZ)-search_results">
                       ASCII Gridded XYZ (XYZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-asciitxt-search_results" name="fmt" type="checkbox" value="asciitxt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-asciitxt-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results" name="fmt" type="checkbox" value="Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)-search_results">
                       ASCII Text Files (non-csv, non-xyz gridded, non-tab separated format)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-bag-search_results" name="fmt" type="checkbox" value="bag" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-bag-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results" name="fmt" type="checkbox" value="Open Format | Bathymetric Attributed Grid (BAG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open Format | Bathymetric Attributed Grid (BAG)-search_results">
                       Bathymetric Attributed Grid (BAG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dxf-search_results" name="fmt" type="checkbox" value="dxf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dxf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | CAD Data eXchange Format (DXF)-search_results" name="fmt" type="checkbox" value="Open format | CAD Data eXchange Format (DXF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | CAD Data eXchange Format (DXF)-search_results">
                       CAD Data eXchange Format (DXF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dwg-search_results" name="fmt" type="checkbox" value="dwg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dwg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | CAD Drawing file (DWG)-search_results" name="fmt" type="checkbox" value="Proprietary format | CAD Drawing file (DWG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | CAD Drawing file (DWG)-search_results">
                       CAD Drawing file (DWG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-csw-search_results" name="fmt" type="checkbox" value="csw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-csw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results" name="fmt" type="checkbox" value="OGC Web Services | Catalogue Service for the Web (CSW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | Catalogue Service for the Web (CSW)-search_results">
                       Catalogue Service for the Web (CSW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-citygml-search_results" name="fmt" type="checkbox" value="citygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-citygml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (Citygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (Citygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (Citygml)-search_results">
                       City GML (Citygml)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dbf-search_results" name="fmt" type="checkbox" value="dbf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dbf-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | dBASE (DBF)-search_results" name="fmt" type="checkbox" value="Open format | dBASE (DBF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | dBASE (DBF)-search_results">
                       dBASE (DBF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ER Mapper (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ER Mapper (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ER Mapper (ECW)-search_results">
                       ER Mapper (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-img-search_results" name="fmt" type="checkbox" value="img" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-img-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDAS IMAGINE (IMG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDAS IMAGINE (IMG)-search_results">
                       ERDAS IMAGINE (IMG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-raw-search_results" name="fmt" type="checkbox" value="raw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-raw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ERDASRaw (RAW)-search_results" name="fmt" type="checkbox" value="Proprietary format | ERDASRaw (RAW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ERDASRaw (RAW)-search_results">
                       ERDASRaw (RAW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gsf-all-search_results" name="fmt" type="checkbox" value="gsf-all" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gsf-all-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Generic Sensor Format (ALL)-search_results" name="fmt" type="checkbox" value="Proprietary format | Generic Sensor Format (ALL)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Generic Sensor Format (ALL)-search_results">
                       Generic Sensor Format (ALL)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gif-search_results" name="fmt" type="checkbox" value="gif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gif-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | Graphical Interchange Format (GIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Graphical Interchange Format (GIF)-search_results">
                       Graphical Interchange Format (GIF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geotiff-search_results" name="fmt" type="checkbox" value="geotiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geotiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results" name="fmt" type="checkbox" value="Open format | Geo Tagged Image File Format (GeoTIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geo Tagged Image File Format (GeoTIFF)-search_results">
                       Geo Tagged Image File Format (GeoTIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gml-search_results" name="fmt" type="checkbox" value="gml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Geography Markup Language (GML)-search_results" name="fmt" type="checkbox" value="Open format | Geography Markup Language (GML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Geography Markup Language (GML)-search_results">
                       Geography Markup Language (GML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpkg-search_results" name="fmt" type="checkbox" value="gpkg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpkg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoPackage (GPKG)-search_results" name="fmt" type="checkbox" value="Open format | GeoPackage (GPKG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoPackage (GPKG)-search_results">
                       GeoPackage (GPKG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geo-search_results" name="fmt" type="checkbox" value="geo" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geo-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GeoRSS (Geo)-search_results" name="fmt" type="checkbox" value="Open format | GeoRSS (Geo)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GeoRSS (Geo)-search_results">
                       GeoRSS (Geo)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gpx-search_results" name="fmt" type="checkbox" value="gpx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gpx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GPS Exchange Format (GPX)-search_results" name="fmt" type="checkbox" value="Open format | GPS Exchange Format (GPX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GPS Exchange Format (GPX)-search_results">
                       GPS Exchange Format (GPX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-sd-search_results" name="fmt" type="checkbox" value="sd" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-sd-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data (SD)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data (SD)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data (SD)-search_results">
                       Fledermaus scientific data (SD)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-scene-search_results" name="fmt" type="checkbox" value="scene" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-scene-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results" name="fmt" type="checkbox" value="Proprietary format | Fledermaus scientific data scene (SCENE)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Fledermaus scientific data scene (SCENE)-search_results">
                       Fledermaus scientific data scene (SCENE)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-geojson-search_results" name="fmt" type="checkbox" value="geojson" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-geojson-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results" name="fmt" type="checkbox" value="Open format | JavaScript Object Notation (GeoJSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | JavaScript Object Notation (GeoJSON)-search_results">
                       JavaScript Object Notation (GeoJSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-json-search_results" name="fmt" type="checkbox" value="json" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-json-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results" name="fmt" type="checkbox" value="OGC Web Services | JavaScript Object Notation (JSON)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-OGC Web Services | JavaScript Object Notation (JSON)-search_results">
                       JavaScript Object Notation (JSON)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg-search_results" name="fmt" type="checkbox" value="jpeg" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group (JPEG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group (JPEG)-search_results">
                       Joint Photographic Experts Group (JPEG)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-jpeg2000-search_results" name="fmt" type="checkbox" value="jpeg2000" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-jpeg2000-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results" name="fmt" type="checkbox" value="Open format | Joint Photographic Experts Group 2000 (JPEG2000)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Joint Photographic Experts Group 2000 (JPEG2000)-search_results">
                       Joint Photographic Experts Group 2000 (JPEG2000)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kml-search_results" name="fmt" type="checkbox" value="kml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kml-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language (KML)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language (KML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language (KML)-search_results">
                       Keyhole Markup Language (KML)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-kmz-search_results" name="fmt" type="checkbox" value="kmz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-kmz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results" name="fmt" type="checkbox" value="Open format | Keyhole Markup Language Zipped (KMZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Keyhole Markup Language Zipped (KMZ)-search_results">
                       Keyhole Markup Language Zipped (KMZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-las-search_results" name="fmt" type="checkbox" value="las" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-las-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAS)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAS)-search_results">
                       Lidar Data Exchange Format (LAS)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-laz-search_results" name="fmt" type="checkbox" value="laz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-laz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results" name="fmt" type="checkbox" value="Open format | Lidar Data Exchange Format (LAZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Lidar Data Exchange Format (LAZ)-search_results">
                       Lidar Data Exchange Format (LAZ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Lemuel-Ziv and Welch (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-dat-search_results" name="fmt" type="checkbox" value="dat" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-dat-search_results">
-                      Many DAT formats (DAT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Many XML formats (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tab-search_results" name="fmt" type="checkbox" value="tab" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tab-search_results">
-                      MapInfo (TAB)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mif-search_results" name="fmt" type="checkbox" value="mif" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mif-search_results">
-                      MapInfo MIF/MID (MIF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-psv-search_results" name="fmt" type="checkbox" value="psv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-psv-search_results">
-                      Microsoft Office Pipe Separated Values file format (PSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mrsid-search_results" name="fmt" type="checkbox" value="mrsid" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mrsid-search_results">
-                      Multi-resolution Seamless Image Database (MrSID)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ntf-search_results" name="fmt" type="checkbox" value="ntf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ntf-search_results">
-                      National Transfer Format - OS (NTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odp-search_results" name="fmt" type="checkbox" value="odp" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odp-search_results">
-                      Open Document Presentation (ODP)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ods-search_results" name="fmt" type="checkbox" value="ods" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ods-search_results">
-                      Open Document Spreadsheet (ODS)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-odt-search_results" name="fmt" type="checkbox" value="odt" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-odt-search_results">
-                      Open Document Text (ODT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-oft-search_results" name="fmt" type="checkbox" value="oft" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-oft-search_results">
-                      Outlook File Template (OFT)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Packbit (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - 3D (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - GeoReferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Standardized (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-pdf-search_results" name="fmt" type="checkbox" value="pdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-pdf-search_results">
-                      Portable Document Format - Unreferenced (PDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-png-search_results" name="fmt" type="checkbox" value="png" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-png-search_results">
-                      Portable Network Graphic (PNG)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rdf-search_results" name="fmt" type="checkbox" value="rdf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rdf-search_results">
-                      Resource Description Framework (RDF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-xml-search_results" name="fmt" type="checkbox" value="xml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-xml-search_results">
-                      Resource Description Framework (XML)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-rtf-search_results" name="fmt" type="checkbox" value="rtf" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-rtf-search_results">
-                      Rich Text Format (RTF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tsv-search_results" name="fmt" type="checkbox" value="tsv" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tsv-search_results">
-                      Tab Separated Values (TSV)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
-                      Tagged Image File Format (TIFF)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-tiff-search_results" name="fmt" type="checkbox" value="tiff" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-tiff-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Lempel-Ziv and Welch (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Lempel-Ziv and Welch (TIFF)-search_results">
                       Lempel-Ziv and Welch (TIFF)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-parquet-search_results" name="fmt" type="checkbox" value="parquet" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-parquet-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many DAT formats (DAT)-search_results" name="fmt" type="checkbox" value="Open format | Many DAT formats (DAT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many DAT formats (DAT)-search_results">
+                      Many DAT formats (DAT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Many XML formats (XML)-search_results" name="fmt" type="checkbox" value="Open format | Many XML formats (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Many XML formats (XML)-search_results">
+                      Many XML formats (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo (TAB)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo (TAB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo (TAB)-search_results">
+                      MapInfo (TAB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results" name="fmt" type="checkbox" value="Proprietary format | MapInfo MIF/MID (MIF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MapInfo MIF/MID (MIF)-search_results">
+                      MapInfo MIF/MID (MIF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results" name="fmt" type="checkbox" value="Open format | Microsoft Office Pipe Separated Values file format (PSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Microsoft Office Pipe Separated Values file format (PSV)-search_results">
+                      Microsoft Office Pipe Separated Values file format (PSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results" name="fmt" type="checkbox" value="Compressed format | Multi-resolution Seamless Image Database (MrSID)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Multi-resolution Seamless Image Database (MrSID)-search_results">
+                      Multi-resolution Seamless Image Database (MrSID)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | National Transfer Format - OS (NTF)-search_results" name="fmt" type="checkbox" value="Open format | National Transfer Format - OS (NTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | National Transfer Format - OS (NTF)-search_results">
+                      National Transfer Format - OS (NTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Presentation (ODP)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Presentation (ODP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Presentation (ODP)-search_results">
+                      Open Document Presentation (ODP)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Spreadsheet (ODS)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Spreadsheet (ODS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Spreadsheet (ODS)-search_results">
+                      Open Document Spreadsheet (ODS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Open Document Text (ODT)-search_results" name="fmt" type="checkbox" value="Open format | Open Document Text (ODT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Open Document Text (ODT)-search_results">
+                      Open Document Text (ODT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Outlook File Template (OFT)-search_results" name="fmt" type="checkbox" value="Proprietary format | Outlook File Template (OFT)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Outlook File Template (OFT)-search_results">
+                      Outlook File Template (OFT)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Compressed format | Packbit (TIFF)-search_results" name="fmt" type="checkbox" value="Compressed format | Packbit (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Compressed format | Packbit (TIFF)-search_results">
+                      Packbit (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - 3D (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - 3D (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - 3D (PDF)-search_results">
+                      Portable Document Format - 3D (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - GeoReferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - GeoReferenced (PDF)-search_results">
+                      Portable Document Format - GeoReferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Standardized (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Standardized (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Standardized (PDF)-search_results">
+                      Portable Document Format - Standardized (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results" name="fmt" type="checkbox" value="Open format | Portable Document Format - Unreferenced (PDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Document Format - Unreferenced (PDF)-search_results">
+                      Portable Document Format - Unreferenced (PDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Portable Network Graphic (PNG)-search_results" name="fmt" type="checkbox" value="Open format | Portable Network Graphic (PNG)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Portable Network Graphic (PNG)-search_results">
+                      Portable Network Graphic (PNG)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (RDF)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (RDF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (RDF)-search_results">
+                      Resource Description Framework (RDF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Resource Description Framework (XML)-search_results" name="fmt" type="checkbox" value="Open format | Resource Description Framework (XML)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Resource Description Framework (XML)-search_results">
+                      Resource Description Framework (XML)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Rich Text Format (RTF)-search_results" name="fmt" type="checkbox" value="Open format | Rich Text Format (RTF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Rich Text Format (RTF)-search_results">
+                      Rich Text Format (RTF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Tab Separated Values (TSV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Tab Separated Values (TSV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Tab Separated Values (TSV)-search_results">
+                      Tab Separated Values (TSV)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Tagged Image File Format (TIFF)-search_results" name="fmt" type="checkbox" value="Open format | Tagged Image File Format (TIFF)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Tagged Image File Format (TIFF)-search_results">
+                      Tagged Image File Format (TIFF)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Apache Parquet (PARQUET)-search_results" name="fmt" type="checkbox" value="Open format | Apache Parquet (PARQUET)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Apache Parquet (PARQUET)-search_results">
                       Apache Parquet (PARQUET)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-cicmptygml-search_results" name="fmt" type="checkbox" value="cicmptygml" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-cicmptygml-search_results">
-                      City GML (CiCompressedtygml)
-                    </label>
-                  </div>
-                
-                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fastq-search_results" name="fmt" type="checkbox" value="fastq" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fastq-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results" name="fmt" type="checkbox" value="Open format | FASTQ Biological Sequence File (FASTQ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTQ Biological Sequence File (FASTQ)-search_results">
                       FASTQ Biological Sequence File (FASTQ)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-fasta-search_results" name="fmt" type="checkbox" value="fasta" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-fasta-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results" name="fmt" type="checkbox" value="Open format | FASTA Biological Sequence File (FASTA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | FASTA Biological Sequence File (FASTA)-search_results">
                       FASTA Biological Sequence File (FASTA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-flac-search_results" name="fmt" type="checkbox" value="flac" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-flac-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results" name="fmt" type="checkbox" value="Open format | Free Lossless Audio Codec (FLAC)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Free Lossless Audio Codec (FLAC)-search_results">
                       Free Lossless Audio Codec (FLAC)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp3-search_results" name="fmt" type="checkbox" value="mp3" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp3-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results" name="fmt" type="checkbox" value="Open format | MPEG Audio Layer 3 (MP3)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | MPEG Audio Layer 3 (MP3)-search_results">
                       MPEG Audio Layer 3 (MP3)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-r-search_results" name="fmt" type="checkbox" value="r" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-r-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | R Script File (R)-search_results" name="fmt" type="checkbox" value="Open format | R Script File (R)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | R Script File (R)-search_results">
                       R Script File (R)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-avi-search_results" name="fmt" type="checkbox" value="avi" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-avi-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Audio Video Interleave (AVI)-search_results" name="fmt" type="checkbox" value="Proprietary format | Audio Video Interleave (AVI)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Audio Video Interleave (AVI)-search_results">
                       Audio Video Interleave (AVI)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-ecw-search_results" name="fmt" type="checkbox" value="ecw" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-ecw-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results" name="fmt" type="checkbox" value="Proprietary format | Enhanced Compression Wavelet (ECW)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Enhanced Compression Wavelet (ECW)-search_results">
                       Enhanced Compression Wavelet (ECW)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyr-search_results" name="fmt" type="checkbox" value="lyr" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyr-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYR)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYR)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYR)-search_results">
                       ESRI Layer (LYR)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-lyrx-search_results" name="fmt" type="checkbox" value="lyrx" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-lyrx-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI Layer (LYRX)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI Layer (LYRX)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI Layer (LYRX)-search_results">
                       ESRI Layer (LYRX)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mp4-search_results" name="fmt" type="checkbox" value="mp4" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mp4-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results" name="fmt" type="checkbox" value="Proprietary format | MPEG-4 Video file (MP4)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MPEG-4 Video file (MP4)-search_results">
                       MPEG-4 Video file (MP4)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-mov-search_results" name="fmt" type="checkbox" value="mov" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-mov-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | QuickTime File Format (MOV)-search_results" name="fmt" type="checkbox" value="Proprietary format | QuickTime File Format (MOV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | QuickTime File Format (MOV)-search_results">
                       QuickTime File Format (MOV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-wav-search_results" name="fmt" type="checkbox" value="wav" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-wav-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results" name="fmt" type="checkbox" value="Proprietary format | Waveform Audio File Format (WAV)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | Waveform Audio File Format (WAV)-search_results">
                       Waveform Audio File Format (WAV)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-qza-search_results" name="fmt" type="checkbox" value="qza" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-qza-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | QIIME Zipped Artifact (QZA)-search_results" name="fmt" type="checkbox" value="Open format | QIIME Zipped Artifact (QZA)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | QIIME Zipped Artifact (QZA)-search_results">
                       QIIME Zipped Artifact (QZA)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-biom-search_results" name="fmt" type="checkbox" value="biom" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-biom-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Biological Observation Matrix (BIOM)-search_results" name="fmt" type="checkbox" value="Open format | Biological Observation Matrix (BIOM)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Biological Observation Matrix (BIOM)-search_results">
                       Biological Observation Matrix (BIOM)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-gzip-search_results" name="fmt" type="checkbox" value="gzip" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-gzip-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | GNU zip archive (GZIP)-search_results" name="fmt" type="checkbox" value="Open format | GNU zip archive (GZIP)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | GNU zip archive (GZIP)-search_results">
                       GNU zip archive (GZIP)
                     </label>
                   </div>
                 
                   <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
-                    <input class="govuk-checkboxes__input"  id="filters-targz-search_results" name="fmt" type="checkbox" value="targz" data-multiple="true" data-ncea-only="">
-                    <label class="govuk-label govuk-checkboxes__label" for="filters-targz-search_results">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | Compressed tape archive (TAR.GZ)-search_results" name="fmt" type="checkbox" value="Open format | Compressed tape archive (TAR.GZ)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | Compressed tape archive (TAR.GZ)-search_results">
                       Compressed tape archive (TAR.GZ)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results" name="fmt" type="checkbox" value="Proprietary format | ESRI File based Geodatabase (GDB)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | ESRI File based Geodatabase (GDB)-search_results">
+                      ESRI File based Geodatabase (GDB)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Proprietary format | MS Excel (XLS)-search_results" name="fmt" type="checkbox" value="Proprietary format | MS Excel (XLS)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Proprietary format | MS Excel (XLS)-search_results">
+                      MS Excel (XLS)
+                    </label>
+                  </div>
+                
+                  <div class="govuk-checkboxes__item" data-module="govuk-checkboxes">
+                    <input class="govuk-checkboxes__input"  id="filters-Open format | City GML (CiCompressedtygml)-search_results" name="fmt" type="checkbox" value="Open format | City GML (CiCompressedtygml)" data-multiple="true" data-ncea-only="">
+                    <label class="govuk-label govuk-checkboxes__label" for="filters-Open format | City GML (CiCompressedtygml)-search_results">
+                      City GML (CiCompressedtygml)
                     </label>
                   </div>
                 
@@ -6678,8 +6712,8 @@ exports[`Results block template Quick search journey Search results with empty d
 
 </div>
 
-            
-          <div class="filter-options__keyboard-filter-content">
+
+          <div class="filter-options__keyboard-filter-content-search_results">
               <ul class="filter-options__keyboard-filter-list" id="keyboard-filter-list">
               </ul>
           </div>
@@ -6701,6 +6735,7 @@ exports[`Results block template Quick search journey Search results with empty d
     </div>
   </section>
 </form>
+</section>
         </div>
         <div class="govuk-grid-column-two-thirds">
           
@@ -7364,7 +7399,7 @@ exports[`Results block template Quick search journey Search results with error s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37201%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43763%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -7396,6 +7431,7 @@ exports[`Results block template Quick search journey Search results with error s
         <main class="govuk-main-wrapper app-main-class" id="main-content">
           
     <h1 class="govuk-heading-l ">Search results</h1>
+    
     <div class="govuk-grid-row govuk-!-text-align-right">
       
   
@@ -7466,7 +7502,7 @@ exports[`Results block template Quick search journey Search results with error s
     </div>
     <div class="filter-view-block-container">
       <div class="filter-view-block govuk-!-padding-4">
-        <h2 class='govuk-heading-m'>
+        <h2 class='govuk-heading-m filter-heading'>
           Key and filters
         </h2>
         <div class="govuk-section-break--visible"></div>
@@ -7516,7 +7552,7 @@ exports[`Results block template Quick search journey Search results with error s
 
         </div>
         <div id="defra-bounding-box-info" class="govuk-!-margin-bottom-2">Filter your results to reduce the number of bounding boxes</div>
-        <div class="govuk-section-break--visible"></div>
+
         <div data-search-results-url="/natural-capital-ecosystem-assessment/search"></div>
         <div id="map-filter-block" data-action="/natural-capital-ecosystem-assessment/map-filters" data-fetch-map-filters></div>
       </div>
@@ -7585,21 +7621,43 @@ exports[`Results block template Quick search journey Search results with error s
 </div></div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <div class="filters-heading">
-            <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
-              Filters
-            </h2>
-            <div class="filters-buttons">
-              <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-" id="filters-reset-" data-reset-url="">
-                Clear Filters
-              </button>
-              <button type="submit" class="govuk-button" data-module="govuk-button" form="filters-">
-                Apply Filters
-              </button>
-            </div>
-          </div>
-          <div class="govuk-section-break--visible"></div>
-          
+          <section>
+  <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+    Data Scope
+  </h2>
+  <div class="govuk-section-break--visible"></div>
+  <form class="govuk-form-group filter-options__ncea-only" id="scope-form-">
+  <fieldset class="govuk-fieldset">
+    <legend class="filter-options__legend">
+      <h3>Data Scope Filter </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="scope-">
+          NCEA Metadata Only
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="scope-all-">
+          DSP and NCEA Metadata
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</form>
+</section>
+
+<section>  
+  <div class="filters-heading">
+    <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
+      Filters
+    </h2>
+    
+  </div>
+  <div class="govuk-section-break--visible"></div>
+  
 
 
 
@@ -7632,28 +7690,6 @@ exports[`Results block template Quick search journey Search results with error s
 
 <form autocomplete="off" id="filters-">
   <section>
-    <div class="govuk-form-group filter-options__ncea-only">
-      <fieldset class="govuk-fieldset">
-        <legend class="filter-options__legend">
-          <h3>Data Scope Filter </h3>
-        </legend>
-        <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="scope-">
-              NCEA Metadata Only
-            </label>
-          </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
-            <label class="govuk-label govuk-radios__label" for="scope-all-">
-              DSP and NCEA Metadata
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
     <div>
       
     </div>
@@ -7806,8 +7842,8 @@ exports[`Results block template Quick search journey Search results with error s
 
 </div>
 
-            
-          <div class="filter-options__keyboard-filter-content">
+
+          <div class="filter-options__keyboard-filter-content-">
               <ul class="filter-options__keyboard-filter-list" id="keyboard-filter-list">
               </ul>
           </div>
@@ -7829,6 +7865,7 @@ exports[`Results block template Quick search journey Search results with error s
     </div>
   </section>
 </form>
+</section>
         </div>
         <div class="govuk-grid-column-two-thirds">
           

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -248,6 +248,7 @@ export const naturalTabStaticData = {
 
 export const defaultFilters: ISearchFiltersProcessed = {
   nceaOnly: false,
+  hasDSPFiltersRemoved: false,
   keywords: [''],
   license: '',
   categories: [],

--- a/src/utils/processFilterRSortOptions.ts
+++ b/src/utils/processFilterRSortOptions.ts
@@ -26,6 +26,8 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
 
   const nceaOnly = readQueryParams(requestQuery, filterNames.scope) === DataScope.NCEA;
 
+  let hasDSPFiltersRemoved = false;
+
   for (const category of searchFilters) {
     // filter to remove any empty strings
     const catQueryValue = readQueryParams(requestQuery, category.value)
@@ -55,12 +57,16 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
       });
     }
 
+    if (nceaOnly && newCategory.filters.filter((filter) => filter.checked).length !== catQueryValue.length) {
+      hasDSPFiltersRemoved = true;
+    }
     categories.push(newCategory);
   }
 
   return {
     nceaOnly,
     categories: categories,
+    hasDSPFiltersRemoved: hasDSPFiltersRemoved,
     // without the filter if they keywords are empty it will return a 1 element array
     // where the element is just an empty string
     keywords: readQueryParams(requestQuery, filterNames.keywords)

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -41,6 +41,7 @@ export interface ISearchFilterProcessed {
 export type ISearchFilters = ISearchFilter[];
 export interface ISearchFiltersProcessed {
   nceaOnly: boolean;
+  hasDSPFiltersRemoved: boolean;
   categories: ISearchFilterProcessed[];
   keywords: string[];
   license: string;

--- a/src/views/screens/results/template.njk
+++ b/src/views/screens/results/template.njk
@@ -12,6 +12,9 @@
   {% endblock %}
   {% block content %}
     <h1 class="govuk-heading-l ">Search results</h1>
+    {% if dspFilterOptions.hasDSPFiltersRemoved %}
+      <p  class="govuk-body-m">You have reduced the search scope to NCEA only. Some filter items have been removed as they do not apply. See the filter summary to confirm the current filter choices.</p>
+    {% endif %}
     <div class="govuk-grid-row govuk-!-text-align-right">
       {{ govukButton({ text: "New search", classes: "govuk-button--secondary", href: routes.homePage, attributes: {
             'data-do-storage-reset': ''


### PR DESCRIPTION
… scope change.

	- I have added the flag called "hasDSPFiltersRemoved" to dspFilterOptions, which will set to false by default,and set to true when ever user swithched to NCEA Only data scope and filters contains the non NCEA Only filter options.

	- Based on the hasDSPFiltersRemoved flag user will see the some description text about the filter removel i.e "You have reduced the search scope to NCEA only. Some filter items have been removed as they do not apply. See the filter summary to confirm the current filter choices." to the user on search result page.

Issued Id: NCEA-174.

### What one thing this PR does?

A sample one-liner about this task.

### Task details

- [Activity ID - Task title/short description](activity_url)

### Other notes

- Additional details about the task
- Important points that other teams or reviewers should be aware of.

### How do these changes look like?

| ![name of the screengrab](URL) |
| ------------------------------ |

### Dev-tested in

1. Local environment

- [Page name/link 1](url)
- [Page name/link 2](url)

2. Dev environment

- [Page name/link 1](url)
- ...
