### PR TITLE
NCEA-187 Add clear/apply filters back to map

### DIFF
--- a/public/scripts/dataModal.js
+++ b/public/scripts/dataModal.js
@@ -5,8 +5,7 @@ import {
   checkDuplicateKeywords,
   createBadgesFromExistingKeywords,
 } from './keywordsFilter.js';
-import { getValidatedFormData } from './filters.js';
-import { invokeMapResultsFormFilters } from './location.js';
+import { setMapFilterFormValues, addMapFilterFormSubmitListener, addMapFilterFormResetListener } from './filters.js';
 
 let scrollPositionY = 0;
 const overlayContainer = document.getElementById('overlay');
@@ -116,73 +115,6 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleOverlayContainer();
     unfreezeScroll();
   }
-
-  /**
-   * Set the values for map result form compared with its value with search result form.
-   * @param {string} mapResultInstance
-   * @param {string} searchResultInstance
-   */
-  const setMapFilterFormValues = (mapResultInstance, searchResultInstance) => {
-    const searchResutlForm = document.getElementById(`filters-${searchResultInstance}`);
-    const mapResultForm = document.getElementById(`filters-${mapResultInstance}`);
-
-    Array.from(searchResutlForm).forEach((element) => {
-      const elementName = element.name;
-      const elementValue = element.value;
-      const mapResultFormElements = mapResultForm.querySelector('[name="' + elementName + '"]');
-      const checkboxValue = elementValue === 'all' ? elementName : elementValue;
-      const mapResultCheckedElements = document.getElementById(`filters-${checkboxValue}-map_results`);
-
-      if (element.type === 'checkbox' && mapResultCheckedElements) {
-        mapResultCheckedElements.checked = element.checked;
-      }
-
-      if (element.type === 'text' && mapResultFormElements) {
-        mapResultFormElements.value = elementValue;
-      }
-    });
-    // manually checked the checkbox value for retired archived from search results form to map results form
-    document.getElementById(`filters-retired-archived-${mapResultInstance}`).checked = document.getElementById(
-      `filters-retired-archived-${searchResultInstance}`,
-    ).checked;
-  };
-
-  /**
-   * Add the subnit form event listner for map results page
-   * @param {string} instance
-   */
-  const addMapFilterFormSubmitListener = (instance) => {
-    const form = document.getElementById(`filters-${instance}`);
-
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      const data = getValidatedFormData(form, instance);
-      invokeMapResultsFormFilters(true, data);
-    });
-  };
-
-  /**
-   * Add the reset form event listner for map results page
-   * @param {string} instance
-   */
-  const addMapFilterFormResetListener = (instance) => {
-    const formSubmit = document.getElementById(`filters-${instance}`);
-
-    formSubmit.addEventListener('reset', (e) => {
-      e.preventDefault();
-      // reset all the map form fields
-      formSubmit.reset();
-      const checkboxes = document.querySelectorAll('.govuk-checkboxes__input');
-      checkboxes.forEach((checkbox) => {
-        checkbox.checked = false;
-      });
-      document.getElementById('filters-date-before-map_results').value = '';
-      document.getElementById('filters-date-after-map_results').value = '';
-      document.getElementById('filters-licence-map_results').value = '';
-      document.getElementById('filters-keywords-map_results').value = '';
-      invokeMapResultsFormFilters(true);
-    });
-  };
 
   window.openDataModal = openDataModal;
   window.closeDataModal = closeDataModal;

--- a/public/scripts/dataModal.js
+++ b/public/scripts/dataModal.js
@@ -5,6 +5,8 @@ import {
   checkDuplicateKeywords,
   createBadgesFromExistingKeywords,
 } from './keywordsFilter.js';
+import { getValidatedFormData } from './filters.js';
+import { invokeMapResultsFormFilters } from './location.js';
 
 let scrollPositionY = 0;
 const overlayContainer = document.getElementById('overlay');
@@ -88,6 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function openMapModal() {
     toggleModalContainer('map-modal');
     freezeScroll();
+    setMapFilterFormValues('map_results', 'search_results');
+    addMapFilterFormSubmitListener('map_results');
+    addMapFilterFormResetListener('map_results');
     invokeKeyboardFilters();
   }
 
@@ -111,6 +116,73 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleOverlayContainer();
     unfreezeScroll();
   }
+
+  /**
+   * Set the values for map result form compared with its value with search result form.
+   * @param {string} mapResultInstance
+   * @param {string} searchResultInstance
+   */
+  const setMapFilterFormValues = (mapResultInstance, searchResultInstance) => {
+    const searchResutlForm = document.getElementById(`filters-${searchResultInstance}`);
+    const mapResultForm = document.getElementById(`filters-${mapResultInstance}`);
+
+    Array.from(searchResutlForm).forEach((element) => {
+      const elementName = element.name;
+      const elementValue = element.value;
+      const mapResultFormElements = mapResultForm.querySelector('[name="' + elementName + '"]');
+      const checkboxValue = elementValue === 'all' ? elementName : elementValue;
+      const mapResultCheckedElements = document.getElementById(`filters-${checkboxValue}-map_results`);
+
+      if (element.type === 'checkbox' && mapResultCheckedElements) {
+        mapResultCheckedElements.checked = element.checked;
+      }
+
+      if (element.type === 'text' && mapResultFormElements) {
+        mapResultFormElements.value = elementValue;
+      }
+    });
+    // manually checked the checkbox value for retired archived from search results form to map results form
+    document.getElementById(`filters-retired-archived-${mapResultInstance}`).checked = document.getElementById(
+      `filters-retired-archived-${searchResultInstance}`,
+    ).checked;
+  };
+
+  /**
+   * Add the subnit form event listner for map results page
+   * @param {string} instance
+   */
+  const addMapFilterFormSubmitListener = (instance) => {
+    const form = document.getElementById(`filters-${instance}`);
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const data = getValidatedFormData(form, instance);
+      invokeMapResultsFormFilters(true, data);
+    });
+  };
+
+  /**
+   * Add the reset form event listner for map results page
+   * @param {string} instance
+   */
+  const addMapFilterFormResetListener = (instance) => {
+    const formSubmit = document.getElementById(`filters-${instance}`);
+
+    formSubmit.addEventListener('reset', (e) => {
+      e.preventDefault();
+      // reset all the map form fields
+      formSubmit.reset();
+      const checkboxes = document.querySelectorAll('.govuk-checkboxes__input');
+      checkboxes.forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+      document.getElementById('filters-date-before-map_results').value = '';
+      document.getElementById('filters-date-after-map_results').value = '';
+      document.getElementById('filters-licence-map_results').value = '';
+      document.getElementById('filters-keywords-map_results').value = '';
+      invokeMapResultsFormFilters(true);
+    });
+  };
 
   window.openDataModal = openDataModal;
   window.closeDataModal = closeDataModal;

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -1,3 +1,5 @@
+import { invokeMapResultsFormFilters } from './location.js';
+
 const filtersInstance = 'search_results';
 
 const searchResultSortFormId = 'sort_results';
@@ -326,6 +328,74 @@ const attachSearchResultsSortChangeListener = () => {
   }
 };
 
+/**
+ * Set the values for map result form compared with its value with search result form.
+ * @param {string} mapResultInstance
+ * @param {string} searchResultInstance
+ */
+const setMapFilterFormValues = (mapResultInstance, searchResultInstance) => {
+  const searchResutlForm = document.getElementById(`filters-${searchResultInstance}`);
+  const mapResultForm = document.getElementById(`filters-${mapResultInstance}`);
+
+  Array.from(searchResutlForm).forEach((element) => {
+    const elementName = element.name;
+    const elementValue = element.value;
+    const mapResultFormElements = mapResultForm.querySelector('[name="' + elementName + '"]');
+    const checkboxValue = elementValue === 'all' ? elementName : elementValue;
+    const mapResultCheckedElements = document.getElementById(`filters-${checkboxValue}-map_results`);
+
+    if (element.type === 'checkbox' && mapResultCheckedElements) {
+      mapResultCheckedElements.checked = element.checked;
+    }
+
+    if (element.type === 'text' && mapResultFormElements) {
+      mapResultFormElements.value = elementValue;
+    }
+  });
+  // manually checked the checkbox value for retired archived from search results form to map results form
+  document.getElementById(`filters-retired-archived-${mapResultInstance}`).checked = document.getElementById(
+    `filters-retired-archived-${searchResultInstance}`,
+  ).checked;
+};
+
+/**
+ * Add the subnit form event listner for map results page
+ * @param {string} instance
+ */
+const addMapFilterFormSubmitListener = (instance) => {
+  const form = document.getElementById(`filters-${instance}`);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = getValidatedFormData(form, instance);
+    invokeMapResultsFormFilters(true, data);
+  });
+};
+
+/**
+ * Add the reset form event listner for map results page
+ * @param {string} instance
+ */
+const addMapFilterFormResetListener = (instance) => {
+  const formSubmit = document.getElementById(`filters-${instance}`);
+
+  formSubmit.addEventListener('reset', (e) => {
+    e.preventDefault();
+    // reset all the map form fields
+    formSubmit.reset();
+    const checkboxes = document.querySelectorAll('.govuk-checkboxes__input');
+    checkboxes.forEach((checkbox) => {
+      checkbox.checked = false;
+    });
+    document.getElementById('filters-date-before-map_results').value = '';
+    document.getElementById('filters-date-after-map_results').value = '';
+    document.getElementById('filters-licence-map_results').value = '';
+    document.getElementById('filters-keywords-map_results').value = '';
+    invokeMapResultsFormFilters(true);
+    document.getElementById(`filters-retired-archived-map_results`).checked = false;
+  });
+};
+
 document.addEventListener('DOMContentLoaded', () => {
   attachSearchResultsSortChangeListener();
 
@@ -343,4 +413,7 @@ export {
   filtersInstance,
   addScopeChangeListener,
   getValidatedFormData,
+  setMapFilterFormValues,
+  addMapFilterFormResetListener,
+  addMapFilterFormSubmitListener,
 };

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -342,4 +342,5 @@ export {
   appendMetaSearchParams,
   filtersInstance,
   addScopeChangeListener,
+  getValidatedFormData,
 };

--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -5,6 +5,8 @@ import {
   appendMetaSearchParams,
   addScopeChangeListener,
   getValidatedFormData,
+  addMapFilterFormSubmitListener,
+  addMapFilterFormResetListener,
 } from './filters.js';
 
 const mapResultsInstance = 'map_results';
@@ -619,6 +621,8 @@ const getMapFilters = async (path) => {
 
     addCategoryAccordionToggleListeners(mapResultsInstance);
     addScopeChangeListener(mapResultsInstance, mapResultsScopeCallback);
+    addMapFilterFormSubmitListener(mapResultsInstance);
+    addMapFilterFormResetListener(mapResultsInstance);
   }
 };
 

--- a/src/views/partials/results/sidebar.njk
+++ b/src/views/partials/results/sidebar.njk
@@ -6,12 +6,11 @@
   {% include 'partials/results/scope.njk' %}
 </section>
 
-<section>  
+<section>
   <div class="filters-heading">
     <h2 class='govuk-heading-m filter-heading govuk-!-margin-bottom-2'>
       Filters
     </h2>
-    {% if filterInstance == 'search_results' %}
       <div class="filters-buttons">
         <button type="reset" class="govuk-button govuk-button--secondary" data-module="govuk-button" form="filters-{{filterInstance}}" id="filters-reset-{{filterInstance}}" data-reset-url="{{dspFilterReset}}">
           Clear Filters
@@ -20,7 +19,6 @@
           Apply Filters
         </button>
       </div>
-    {% endif %}
   </div>
   <div class="govuk-section-break--visible"></div>
   {% include 'partials/results/filters.njk' %}


### PR DESCRIPTION
### What one thing this PR does?

In the code PR, I have added the Apply Filter and Clear Filter buttons on the map view section. Now the map view section, will also behaves like same as search result filters. When a user selects the filter items present on the map view section, and then clicks on the Apply filters, then it will call invokeMapResults(true) function will all the applied form filters. If user clicks on clearFilters, then it will clear all the filters and call invokeMapResults().

### Task details

- [NCEA-187 - Add clear/apply filters back to map](https://dsp-support.atlassian.net/browse/NCEA-187)

### Other notes

Also added a scenarios, when a user selects any filters on the search result page without clicking the Apply Filters. If user clicks on the map view, then all the filters will also get applied on the map results filter sections.

### How do these changes look like?
![Screenshot 2025-02-17 231535](https://github.com/user-attachments/assets/a7df711e-061c-4d0d-8358-cb91ec994d86)


### Dev-tested in

- [Map View Section](http://localhost:3000/natural-capital-ecosystem-assessment/search?q=disease&rpp=20&srt=most_relevant&jry=qs&pg=1&scope=all)
