### PR TITLE
feat(frontend): Filter Atom feeds to just NCEA related.

### DIFF
--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38845%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44583%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Details route template Document details with data Check status code and
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33283%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43403%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -1588,7 +1588,7 @@ exports[`Details route template Document details with partial data Check status 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41309%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42189%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
@@ -247,67 +247,128 @@ exports[`Feeds Screen Feeds > Sanpshot verification should match the Feeds scree
   
     <div>
     
-      <h2 class="govuk-heading-m">Environment</h2>
+      <h2 class="govuk-heading-m">NCEA – Natural England</h2>
       <ul class="govuk-list">
         
           <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">The Habitat Target: creating and restoring habitats across England</h3>
+            <h3 class="govuk-heading-s">From AI to underwater microphones: improving the evidence base for marine mammals </h3>
             <div class="captions-section">
-              <small><b>Author: </b>Iram Qureshi</small>
-              <small><b>Published on : </b>05 February 2025 10:32:20</small>
+              <small><b>Author: </b>Samantha Parker</small>
+              <small><b>Published on : </b>13 November 2024 08:13:48</small>
             </div>
-            <p class="govuk-body">The Government is working towards meeting the legally binding biodiversity target to restore or create more than 500,000 hectares of wildlife-rich habitat by 2042 in England. Read this post to find out what action the Government is taking to achieve this target.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2025/02/05/the-habitat-target-creating-and-restoring-habitats-across-england/" target="_blank">The Habitat Target: creating and restoring habitats across England</a>
+            <p class="govuk-body">By Samantha Parker and Emma Milner, Natural England marine mammal senior specialists  Why are seal population numbers changing so fast along our coasts? How are porpoise feeding patterns changing as our seas become increasingly crowded? And how does the health …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/11/13/from-ai-to-underwater-microphones-improving-the-evidence-base-for-marine-mammals/" target="_blank">From AI to underwater microphones: improving the evidence base for marine mammals </a>
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
           </li>
         
           <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Introducing the deposit return scheme for drinks containers</h3>
+            <h3 class="govuk-heading-s">Mapping our green and blue spaces: the green infrastructure mapping project</h3>
             <div class="captions-section">
-              <small><b>Author: </b>Shehab Choudhury</small>
-              <small><b>Published on : </b>31 January 2025 08:41:07</small>
+              <small><b>Author: </b>Natural England</small>
+              <small><b>Published on : </b>31 October 2024 15:33:05</small>
             </div>
-            <p class="govuk-body">This week, the Government pledged to end the throwaway society and clean up Britain; as it implements legislation for the deposit return scheme for drinks containers in England and Northern Ireland. 
+            <p class="govuk-body">Martin Moss, senior officer for green infrastructure mapping, and Sarah Parrott, higher officer for engagement and impact If you looked at a map of your local area, could you identify the accessible green spaces? What about the blue ones? If …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/10/31/mapping-our-green-and-blue-spaces-the-green-infrastructure-mapping-project/" target="_blank">Mapping our green and blue spaces: the green infrastructure mapping project</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">Green Infrastructure: delivering quality of life and environmental benefits for communities</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Natural England</small>
+              <small><b>Published on : </b>27 August 2024 16:44:57</small>
+            </div>
+            <p class="govuk-body">David Drake, Director, People &amp;#38; Nature at Natural England In January 2023, Natural England launched the Green Infrastructure (GI) Framework to support the creation of good quality Green Infrastructure which maximises benefits for people and nature. GI helps local authorities, …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/08/27/green-infrastructure-delivering-quality-of-life-and-environmental-benefits-for-communities/" target="_blank">Green Infrastructure: delivering quality of life and environmental benefits for communities</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">With a lot of help from our friends: assembling an England Peat Map</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Andrew Webb</small>
+              <small><b>Published on : </b>06 August 2024 10:32:18</small>
+            </div>
+            <p class="govuk-body">Contributors: Andrew Webb, Principal advisor, England Peat Map. Tom Hunt, Data engagement lead, England Peat Map. Sarah Parrott, Engagement and impact lead advisor, NCEA. Elizabeth Mitchell, Engagement and impact senior advisor, NCEA &amp;#160; How do you make a map of something that’s largely underground, …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/08/06/with-a-lot-of-help-from-our-friends-assembling-an-england-peat-map/" target="_blank">With a lot of help from our friends: assembling an England Peat Map</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">The Chief Scientist Report: 2023</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Natural England</small>
+              <small><b>Published on : </b>02 August 2024 11:28:50</small>
+            </div>
+            <p class="govuk-body">Professor Sallie Bailey, Chief Scientist at Natural England, tells us about the publication of Natural England’s sixth Chief Scientist Report &amp;#160; This Report, the sixth in the series, focusses on the impact our work has and – crucially - how …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/08/02/the-chief-scientist-report-2023/" target="_blank">The Chief Scientist Report: 2023</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">England Ecosystem Survey: introducing England’s largest ever field survey</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Isabel Sloman</small>
+              <small><b>Published on : </b>03 April 2024 12:20:13</small>
+            </div>
+            <p class="govuk-body">By Isabel Sloman, Manager, and Elizabeth Mitchell, Senior Advisor for Engagement and Impact, Natural Capital and Ecosystem Assessment programme The England Ecosystem Survey (EES), the largest field survey ever undertaken in the UK, is now well underway. Working at thousands …</p>
+            <a href="https://naturalengland.blog.gov.uk/2024/04/03/england-ecosystem-survey-introducing-englands-largest-ever-field-survey/" target="_blank">England Ecosystem Survey: introducing England’s largest ever field survey</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">Green Infrastructure: creating habitable towns and cities fit for the future</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Natural England</small>
+              <small><b>Published on : </b>08 November 2023 14:57:33</small>
+            </div>
+            <p class="govuk-body">&amp;#160; This week is Green Infrastructure week, a celebration of green infrastructure design and best practices. Green infrastructure is a network of natural spaces designed to deliver benefits for people and the planet. The below video details green infrastructure in …</p>
+            <a href="https://naturalengland.blog.gov.uk/2023/11/08/green-infrastructure-creating-habitable-towns-and-cities-fit-for-the-future/" target="_blank">Green Infrastructure: creating habitable towns and cities fit for the future</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">How many mussels in Morecambe Bay? Understanding the value of mudflats and sandflats for birds, humans, and the ecosystems we share</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Elizabeth Mitchell</small>
+              <small><b>Published on : </b>24 July 2023 16:42:08</small>
+            </div>
+            <p class="govuk-body">By Louise Whatley, Marine Ecology Specialist and Elizabeth Mitchell, Senior Advisor for Engagement and Impact  As summer sets in in earnest, millions of us will head to the coast. In between dropping our ice-creams on our feet and taking a …</p>
+            <a href="https://naturalengland.blog.gov.uk/2023/07/24/how-many-mussels-in-morecambe-bay-understanding-the-value-of-mudflats-and-sandflats-for-birds-humans-and-the-ecosystems-we-share/" target="_blank">How many mussels in Morecambe Bay? Understanding the value of mudflats and sandflats for birds, humans, and the ecosystems we share</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">Working towards a Peat Data Standard</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Mike Prince</small>
+              <small><b>Published on : </b>12 January 2023 09:37:14</small>
+            </div>
+            <p class="govuk-body">By Mike Prince, Natural England The England Peat Map project is mapping the extent, depth and condition of England’s peat, using new and existing field survey data, satellite Earth observation, and a variety of modelling methods. Mapping England’s peat can …</p>
+            <a href="https://naturalengland.blog.gov.uk/2023/01/12/working-towards-a-peat-data-standard/" target="_blank">Working towards a Peat Data Standard</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+          <li class="govuk-width-container feed-container">
+            <h3 class="govuk-heading-s">Taking an evidence led approach to delivery of the Government’s tree target</h3>
+            <div class="captions-section">
+              <small><b>Author: </b>Tim Hill</small>
+              <small><b>Published on : </b>15 June 2022 10:59:12</small>
+            </div>
+            <p class="govuk-body">The UK Government’s ambition to increase tree and woodland cover in England from 14 to 17%, by more than trebling annual planting rates by 2050, represents a major shift in land use policy. As well as enhancing carbon sequestration, new …</p>
+            <a href="https://naturalengland.blog.gov.uk/2022/06/15/taking-an-evidence-led-approach-to-delivery-of-the-governments-tree-target/" target="_blank">Taking an evidence led approach to delivery of the Government’s tree target</a>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+          </li>
+        
+      </ul>
+    </div>
+    
 
-Read our post to find out more.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2025/01/31/introducing-the-deposit-return-scheme-for-drinks-containers/" target="_blank">Introducing the deposit return scheme for drinks containers</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Newly recognised Official Statistic tracks the environmental impact of our consumption</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Ethan Workman</small>
-              <small><b>Published on : </b>20 January 2025 09:37:51</small>
-            </div>
-            <p class="govuk-body">Nearly all the food we eat, clothes we wear, and cosmetics we use contain commodities grown in fields and forests around the world. 
-
-The environmental impact of our consumption habits is becoming more widely understood. To understand this, in this post, JNNC Evidence Specialist Ethan Workman discusses the Global Environmental Impacts of Consumption (GEIC) Indicator which is gathering key insights on this.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2025/01/20/newly-recognised-official-statistic-tracks-the-environmental-impact-of-our-consumption/" target="_blank">Newly recognised Official Statistic tracks the environmental impact of our consumption</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Nature and farming friendly solutions drive agricultural transformation in the Peak District</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Ben Rodgers</small>
-              <small><b>Published on : </b>14 January 2025 13:43:25</small>
-            </div>
-            <p class="govuk-body">In this post, Catchment Sensitive Farming Adviser Ben Rodgers shares an example of nature and farming-friendly solutions driving agricultural transformation in the Peak District.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2025/01/14/nature-and-farming-friendly-solutions-drive-agricultural-transformation-in-the-peak-district/" target="_blank">Nature and farming friendly solutions drive agricultural transformation in the Peak District</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Historic rights of way saved</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Environment blog team</small>
-              <small><b>Published on : </b>03 January 2025 09:36:27</small>
-            </div>
-            <p class="govuk-body">Wishing you a very happy New Year from the Defra Environment blog team. It’s a time of year when many of us enjoy a brisk winter’s walk with our families. On Boxing Day, a favourite day for rambling, the government …</p>
-            <a href="https://defraenvironment.blog.gov.uk/2025/01/03/historic-rights-of-way-saved/" target="_blank">Historic rights of way saved</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
+  
+    <div>
+    
+      <h2 class="govuk-heading-m">NCEA programme – Environment</h2>
+      <ul class="govuk-list">
         
           <li class="govuk-width-container feed-container">
             <h3 class="govuk-heading-s">Living England: a national habitat map for everyone </h3>
@@ -321,166 +382,24 @@ The environmental impact of our consumption habits is becoming more widely under
           </li>
         
           <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">75th Anniversary of the National Parks Act: New legislation to ensure Protected Landscapes are fit for the future</h3>
+            <h3 class="govuk-heading-s">Why monitoring matters: showcasing the Natural Capital and Ecosystem Assessment programme</h3>
             <div class="captions-section">
-              <small><b>Author: </b>Amber Inman</small>
-              <small><b>Published on : </b>16 December 2024 14:27:42</small>
+              <small><b>Author: </b>David Jones</small>
+              <small><b>Published on : </b>16 October 2024 11:16:25</small>
             </div>
-            <p class="govuk-body">Today is the 75th anniversary of the 1949 National Parks and Access to the Countryside Act. Read how the government is marking the occasion by empowering our Protected Landscapes.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2024/12/16/75th-anniversary-of-the-national-parks-act-new-legislation-to-ensure-protected-landscapes-are-fit-for-the-future/" target="_blank">75th Anniversary of the National Parks Act: New legislation to ensure Protected Landscapes are fit for the future</a>
+            <p class="govuk-body">In this post, David Jones, Senior Responsible Owner for the terrestrial arm of Defra’s largest research and development programme - the NCEA, shares reflections from the recent stakeholder showcase event.</p>
+            <a href="https://defraenvironment.blog.gov.uk/2024/10/16/why-monitoring-matters-showcasing-the-natural-capital-and-ecosystem-assessment-programme/" target="_blank">Why monitoring matters: showcasing the Natural Capital and Ecosystem Assessment programme</a>
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
           </li>
         
           <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Sustainable festivities: how you can reduce your waste this Christmas</h3>
+            <h3 class="govuk-heading-s">Mapping our natural assets: the Natural Capital and Ecosystem Assessment programme</h3>
             <div class="captions-section">
-              <small><b>Author: </b>Environment blog team</small>
-              <small><b>Published on : </b>13 December 2024 09:15:39</small>
+              <small><b>Author: </b>Sarah Adcock</small>
+              <small><b>Published on : </b>28 March 2024 12:00:21</small>
             </div>
-            <p class="govuk-body">The festive period is a time to celebrate and enjoy decorating trees, giving gifts and eating lots of delicious food. But all of this can have an impact on the environment. In this post, the Environment blog team will share actions you can take to enjoy festivities sustainably.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2024/12/13/sustainable-festivities-how-you-can-reduce-your-waste-this-christmas/" target="_blank">Sustainable festivities: how you can reduce your waste this Christmas</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Celebrating one year of Projects for Nature</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Justin Francis</small>
-              <small><b>Published on : </b>12 December 2024 09:24:08</small>
-            </div>
-            <p class="govuk-body">It has been one year since Projects for Nature was launched. In this post, Justin Francis, the nature lead for The Council for Sustainable Business, shares his reflections.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2024/12/12/celebrating-one-year-of-projects-for-nature/" target="_blank">Celebrating one year of Projects for Nature</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">New Tree Planting Taskforce launched during National Tree Week</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Environment blog team</small>
-              <small><b>Published on : </b>28 November 2024 17:20:50</small>
-            </div>
-            <p class="govuk-body">A new Tree Planting Taskforce has been launched today to oversee the planting of millions of trees across the UK. In this post, the Environment blog team will highlight what this means, as well as some other ways we’re celebrating the week.</p>
-            <a href="https://defraenvironment.blog.gov.uk/2024/11/28/new-tree-planting-taskforce-launched-during-national-trees-week/" target="_blank">New Tree Planting Taskforce launched during National Tree Week</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-      </ul>
-    </div>
-    
-
-  
-    <div>
-    
-      <h2 class="govuk-heading-m">Natural England</h2>
-      <ul class="govuk-list">
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Harnessing Nature-based Solutions to help combat flooding</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>17 February 2025 13:29:51</small>
-            </div>
-            <p class="govuk-body">As climate change brings more frequent and severe flooding, innovative solutions are emerging to tackle these challenges. Working with nature, not against it, Natural England is proposing schemes to help tackle flooding in Norfolk and Suffolk.&amp;#160;&amp;#160; Projects in our region …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/17/harnessing-nature-based-solutions-to-help-combat-flooding/" target="_blank">Harnessing Nature-based Solutions to help combat flooding</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">How can Nature-Based Solutions address the climate and Nature crises?</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Tony Juniper</small>
-              <small><b>Published on : </b>11 February 2025 10:38:55</small>
-            </div>
-            <p class="govuk-body">Keynote speech by Tony Juniper CBE, Chair of Natural England, at Nature Returns conference, 6 February 2025 It is an absolute pleasure to be here today and to see this latest journey in what has been a decades-long process of …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/11/how-can-nature-based-solutions-address-the-climate-and-nature-crises/" target="_blank">How can Nature-Based Solutions address the climate and Nature crises?</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Apprenticeship Week: Developing the Skills for Nature’s Recovery</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>10 February 2025 08:05:00</small>
-            </div>
-            <p class="govuk-body">To celebrate Apprenticeship Week 2025, Ecologist Apprentice, Annalise Machin, shares her apprenticeship journey with Natural England, highlighting the impact her developing skills will have for nature’s recovery. I have always had an interest in in the natural world, loving the …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/10/apprenticeship-week-developing-the-skills-for-natures-recovery/" target="_blank">Apprenticeship Week: Developing the Skills for Nature’s Recovery</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Helping nature to recover and thrive in the Wye Valley in Derbyshire</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>07 February 2025 15:26:53</small>
-            </div>
-            <p class="govuk-body">Ruth Keeley, Wye Valley Nature Recovery Project Senior Officer Back in 2022, Natural England and Defra announced five unique Nature Recovery Projects (NRP) across the Peak District, West Midlands, Cambridgeshire, Norfolk and Somerset. Since then, a further seven projects have …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/07/helping-nature-to-recover-and-thrive-in-the-wye-valley-in-derbyshire/" target="_blank">Helping nature to recover and thrive in the Wye Valley in Derbyshire</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Three churrs for the heathland bird survey</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Alison Giacomelli</small>
-              <small><b>Published on : </b>05 February 2025 09:19:57</small>
-            </div>
-            <p class="govuk-body">By Alison Giacomelli, Senior Specialist – Ornithology, Natural England Heathlands are home to the eerie sound of churring Nightjars, sweet melody of singing Woodlarks and the rattling song of Dartford Warblers. This year teams of volunteers and fieldworkers will be …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/05/three-churrs-for-the-heathland-bird-survey/" target="_blank">Three churrs for the heathland bird survey</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Guest blog: Showcasing successful onsite Biodiversity Net Gain (BNG) project management</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>04 February 2025 12:10:11</small>
-            </div>
-            <p class="govuk-body">In the run up to the first anniversary (12 February) of the introduction of BNG as a mandatory approach to development, making BNG a statutory requirement in all (non-exempt) Town and Country Planning Act applications we invited two open space …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/04/guest-blog-showcasing-successful-onsite-biodiversity-net-gain-bng-project-management/" target="_blank">Guest blog: Showcasing successful onsite Biodiversity Net Gain (BNG) project management</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Green Infrastructure: the catalyst for Urban Greening </h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>03 February 2025 08:05:00</small>
-            </div>
-            <p class="govuk-body">It’s two years since Natural England launched the Green Infrastructure (GI) Framework to support the creation of good quality Green Infrastructure. It’s well documented that we need to build a more sustainable future, and at the forefront of this movement …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/02/03/green-infrastructure-the-catalyst-for-urban-greening/" target="_blank">Green Infrastructure: the catalyst for Urban Greening </a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">&amp;#039;LUF-t off&amp;#039; for a more strategic approach to growth and Nature</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>31 January 2025 12:53:19</small>
-            </div>
-            <p class="govuk-body">By Tony Juniper CBE, Chair of Natural England As the country seeks long-term solutions to our most pressing problems – how to build much-needed homes and infrastructure, safeguard food production and halt and reverse the decline of Nature – we …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/01/31/luf-t-off-for-a-more-strategic-approach-to-growth-and-nature/" target="_blank">&amp;#039;LUF-t off&amp;#039; for a more strategic approach to growth and Nature</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Saving species in Somerset; the work of the Somerset, Coast Levels and Moors Nature Recovery Project</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Natural England</small>
-              <small><b>Published on : </b>30 January 2025 08:00:00</small>
-            </div>
-            <p class="govuk-body">By Simon Phelps – Natural England Over the past three years, the Somerset Coast, Levels and Moors Nature Recovery Project has been working hard to save some of our most threatened wetland species. I’m fortunate to not only be leading …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/01/30/saving-species-in-somerset-the-work-of-the-somerset-coast-levels-and-moors-nature-recovery-project/" target="_blank">Saving species in Somerset; the work of the Somerset, Coast Levels and Moors Nature Recovery Project</a>
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-          </li>
-        
-          <li class="govuk-width-container feed-container">
-            <h3 class="govuk-heading-s">Natural England welcomes £22.1bn investment in Water Industry National Environment Programme</h3>
-            <div class="captions-section">
-              <small><b>Author: </b>Alan Law</small>
-              <small><b>Published on : </b>29 January 2025 12:32:31</small>
-            </div>
-            <p class="govuk-body">The Environment Agency has published the Water Industry National Environment Programme (WINEP), detailing more than 20,000 actions that England’s 19 water companies must complete from now until 2030 to meet their environmental obligations.  Developed with guidance from the Environment Agency …</p>
-            <a href="https://naturalengland.blog.gov.uk/2025/01/29/natural-england-welcomes-22-1bn-investment-in-water-industry-national-environment-programme/" target="_blank">Natural England welcomes £22.1bn investment in Water Industry National Environment Programme</a>
+            <p class="govuk-body">Sarah Adcock and David Jones, Senior Responsible Owners for Defra&#39;s Natural Capital and Ecosystem Assessment programme explain why building a picture of our natural assets and their benefits is the first, crucial step in protecting our environment.</p>
+            <a href="https://defraenvironment.blog.gov.uk/2024/03/28/mapping-our-natural-assets-the-natural-capital-and-ecosystem-assessment-programme/" target="_blank">Mapping our natural assets: the Natural Capital and Ecosystem Assessment programme</a>
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
           </li>
         

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39745%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43487%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`Results block template Guided search journey Search results with empty 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46763%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39303%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -2291,7 +2291,7 @@ exports[`Results block template Guided search journey Search results with error 
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46015%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40885%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -3170,7 +3170,7 @@ exports[`Results block template Quick search journey Search results with data sh
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37397%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39083%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -5489,7 +5489,7 @@ exports[`Results block template Quick search journey Search results with empty d
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40925%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41651%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>
@@ -7560,7 +7560,7 @@ exports[`Results block template Quick search journey Search results with error s
     <div class="govuk-grid-col login">
       
         <p class="govuk-body-m">Welcome, Guest</p>
-        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42859%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
+        <a href="/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43777%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall" class="govuk-link govuk-body-m">Login</a>
       
     </div>
   </header>

--- a/__tests__/routes/web/feeds.spec.ts
+++ b/__tests__/routes/web/feeds.spec.ts
@@ -47,8 +47,10 @@ describe('Feeds Screen', () => {
 
   describe('Feeds > Heading', () => {
     it('should render the Feeds content heading', async () => {
-      expect(document?.querySelectorAll('.govuk-heading-m')?.[1]?.textContent?.trim()).toBe('Environment');
-      expect(document?.querySelectorAll('.govuk-heading-m')?.[2]?.textContent?.trim()).toBe('Natural England');
+      expect(document?.querySelectorAll('.govuk-heading-m')?.[1]?.textContent?.trim()).toBe('NCEA – Natural England');
+      expect(document?.querySelectorAll('.govuk-heading-m')?.[2]?.textContent?.trim()).toBe(
+        'NCEA programme – Environment',
+      );
     });
   });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -263,7 +263,10 @@ export const defaultFilters: ISearchFiltersProcessed = {
 
 export const jwtCookiePrefix = 'auth0-jwt-';
 
-export const atomFeeds = ['https://defraenvironment.blog.gov.uk/feed/', 'https://naturalengland.blog.gov.uk/feed/'];
+export const atomFeeds = [
+  'https://naturalengland.blog.gov.uk/tag/ncea/feed/',
+  'https://defraenvironment.blog.gov.uk/category/research-and-data-analysis/ncea-programme/feed/',
+];
 export const FILTER_VALUES = {
   organisation: 'org',
   searchType: 'st',


### PR DESCRIPTION
	- I have updated the atom feed urls which will gives only the feeds related to NCEA.
           Updated URLS:
           1.  https://naturalengland.blog.gov.uk/tag/ncea/feed/
           2. https://defraenvironment.blog.gov.uk/category/research-and-data-analysis/ncea-programme/feed/
           
Issued Id: NCEA-211.

### What one thing this PR does?

A sample one-liner about this task.

### Task details

- [Activity ID - Task title/short description](activity_url)

### Other notes

- Additional details about the task
- Important points that other teams or reviewers should be aware of.

### How do these changes look like?

| ![name of the screengrab](URL) |
| ------------------------------ |

### Dev-tested in

1. Local environment

- [Page name/link 1](url)
- [Page name/link 2](url)

2. Dev environment

- [Page name/link 1](url)
- ...
