### PR TITLE
fix(elements): Filtering for all on org or Data Format is unchecking some checkboxes

### DIFF
--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -412,7 +412,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -231,7 +231,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34925%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46763%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -443,7 +443,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -855,7 +855,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Details route template Document details with data Check status code and
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46325%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41415%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -1339,7 +1339,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         
@@ -1655,7 +1655,7 @@ exports[`Details route template Document details with partial data Check status 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35783%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33581%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -2512,7 +2512,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
@@ -560,7 +560,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -680,7 +680,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40497%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41233%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -700,7 +700,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -553,7 +553,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Results block template Guided search journey Search results with empty 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34515%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33617%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -2076,7 +2076,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         
@@ -2387,7 +2387,7 @@ exports[`Results block template Guided search journey Search results with error 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33873%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38917%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -3037,7 +3037,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         
@@ -3348,7 +3348,7 @@ exports[`Results block template Quick search journey Search results with data sh
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33721%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45121%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -5386,7 +5386,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         
@@ -5697,7 +5697,7 @@ exports[`Results block template Quick search journey Search results with empty d
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33007%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37009%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -7539,7 +7539,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         
@@ -7850,7 +7850,7 @@ exports[`Results block template Quick search journey Search results with error s
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34735%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41669%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -8500,7 +8500,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.15.0</p>
+          <p>Version: v1.16.0</p>
         </div>
         
         

--- a/src/utils/processFilterRSortOptions.ts
+++ b/src/utils/processFilterRSortOptions.ts
@@ -1,7 +1,7 @@
 import { RequestQuery } from '@hapi/hapi';
 
 import { queryParamKeys, startYearRangeKey, toYearRangeKey, uniqueResourceTypesKey } from './constants';
-import { readQueryParams } from './queryStringHelper';
+import { readListQueryParams, readQueryParams } from './queryStringHelper';
 import {
   DataScope,
   ISearchFilterProcessed,
@@ -30,9 +30,7 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
 
   for (const category of searchFilters) {
     // filter to remove any empty strings
-    const catQueryValue = readQueryParams(requestQuery, category.value)
-      .split(',')
-      .filter((v) => v);
+    const catQueryValue = readListQueryParams(requestQuery, category.value);
 
     const newCategory: ISearchFilterProcessed = {
       name: category.name,
@@ -69,9 +67,7 @@ const processDSPFilterOptions = (requestQuery: RequestQuery): ISearchFiltersProc
     hasDSPFiltersRemoved: hasDSPFiltersRemoved,
     // without the filter if they keywords are empty it will return a 1 element array
     // where the element is just an empty string
-    keywords: readQueryParams(requestQuery, filterNames.keywords)
-      .split(',')
-      .filter((k) => k),
+    keywords: readListQueryParams(requestQuery, filterNames.keywords),
     licence: readQueryParams(requestQuery, filterNames.licence),
     lastUpdated: {
       beforeYear: readQueryParams(requestQuery, filterNames.updatedBefore),
@@ -88,7 +84,7 @@ const processFilterOptions = async (
   const { startYear, toYear, resourceType } = queryParamKeys;
   const startYearValue = readQueryParams(requestQuery, startYear);
   const toYearValue = readQueryParams(requestQuery, toYear);
-  const resourceTypeValue = readQueryParams(requestQuery, resourceType).split(',');
+  const resourceTypeValue = readListQueryParams(requestQuery, resourceType);
 
   const startYearOptions: IAggregationOption[] = filterOptions[startYearRangeKey] ?? [];
   const toYearOptions: IAggregationOption[] = filterOptions[toYearRangeKey] ?? [];

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -91,6 +91,16 @@ const readQueryParams = (
   return searchParams.toString();
 };
 
+const readListQueryParams = (requestQuery: RequestQuery, key: string): string[] => {
+  const keyItems: string | string[] = requestQuery[key];
+
+  if (Array.isArray(keyItems)) {
+    return keyItems; // Return the array directly
+  }
+
+  return keyItems ? keyItems.split(',') : []; // Convert single values to an array
+};
+
 const getClassifierParams = (searchParams: URLSearchParams): Record<string, string> => {
   const level: string = searchParams.get(queryParamKeys.level) ?? '';
   const parent: string = searchParams.get(queryParamKeys.parent) ?? '';
@@ -202,6 +212,7 @@ export {
   getQueryStringParams,
   upsertQueryParams,
   readQueryParams,
+  readListQueryParams,
   generateQueryBuilderPayload,
   generateCountPayload,
   getDateParams,


### PR DESCRIPTION


 Issue: There is a function called "readQueryParams" from this we are reading the filter values and passed it to the result API, this "readQueryParams"
 function will return the query string with comma separated. when it comes to organisation or Data format, in which  some filter items which contain in name it self a comma character is there, hence it treated as a separate filter value when it doing the query string split by comma. this comma separated values contains some other  name which are not expected values.

Fix: I tried to modify "readQueryParams"  function it will return the array of filter items when key value  is available, but it is used in so many places in the source code, for avoiding complexity and more clarity, I created the new function  called " readListQueryParams ", it will only get the list items format from the query params in array format, which are required for the org, data formats, keywords which are passed to the result API. It also avoids the spiting of  the query string items in other places like keywords, data format, because we spitted at this function level.

Issued Id: NCEA-231.  [link](https://dsp-support.atlassian.net/browse/NCEA-231?atlOrigin=eyJpIjoiZGU2MmM5YjIyYTk1NDBmNGExN2UxODU2MzhjMjhiNmIiLCJwIjoiaiJ9)

### What one thing this PR does?

A sample one-liner about this task.

### Task details

- [Activity ID - Task title/short description](activity_url)

### Other notes

- Additional details about the task
- Important points that other teams or reviewers should be aware of.

### How do these changes look like?

| ![name of the screengrab](URL) |
| ------------------------------ |

### Dev-tested in

1. Local environment

- [Page name/link 1](url)
- [Page name/link 2](url)

2. Dev environment

- [Page name/link 1](url)
- ...
