### PR TITLE
Keep bounding boxes in sync with map results

### DIFF
--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -833,6 +833,7 @@ const getMapResults = async (path, fitToMapExtentFlag) => {
           boundingBoxInfo.style.display = 'none';
         }
         mapResults = mapResultsJson.items;
+        polygonFeatureData.length = 0;
         setTimeout(() => {
           drawBoundingBoxWithMarker(fitToMapExtentFlag, true);
         }, 100);


### PR DESCRIPTION
The bounding boxes seemed to always show for every single results on the map, even if you had filtered the results. From investigating, this seemed to be caused because they array that holds the bounding boxes was never cleared from the first search, every time you filtered your results it would just extend the bounding box array, keeping all previous. This had the downside of showing all bounding boxes no matter the filters, but also being not performant as the size of the array an number of bounding boxes grew very quickly.
The fix was to clear the array every time new results are fetched. Testing this it seems to have fixed the issue.

To test for yourself, open the map view and view all bounding boxes, then apply a filter that reduces the number of results, view all bounding boxes again and make sure bounding boxes are not showing on the map where there are no markers.