### PR TITLE
fix(filters): Integrate the sort by UI widget

### DIFF
--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -231,7 +231,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34019%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43039%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
             
           </li>
           

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Details route template Document details with data Check status code and
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36683%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41715%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -1655,7 +1655,7 @@ exports[`Details route template Document details with partial data Check status 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41937%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45777%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33251%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33201%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
             
           </li>
           

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Results block template Guided search journey Search results with empty 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33889%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33069%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -2387,7 +2387,7 @@ exports[`Results block template Guided search journey Search results with error 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37785%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43897%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -3348,7 +3348,7 @@ exports[`Results block template Quick search journey Search results with data sh
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33387%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44023%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -5697,7 +5697,7 @@ exports[`Results block template Quick search journey Search results with empty d
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41935%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42915%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -7850,7 +7850,7 @@ exports[`Results block template Quick search journey Search results with error s
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38065%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35241%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           

--- a/src/services/handlers/searchApi.ts
+++ b/src/services/handlers/searchApi.ts
@@ -23,11 +23,14 @@ const getSearchResults = async (
       const payload = generateSearchQuery(searchFieldsObject, filters);
 
       const headers = credentials ? { Authorization: `Bearer ${credentials?.jwt}` } : null;
-      const agmApiResponse = await fetch(environmentConfig.searchApiUrl, {
-        method: 'POST',
-        ...(headers && { headers }),
-        body: JSON.stringify(payload),
-      });
+      const agmApiResponse = await fetch(
+        `${environmentConfig.searchApiUrl}?sortBy=${searchFieldsObject?.sort ?? 'most_relevant'}`,
+        {
+          method: 'POST',
+          ...(headers && { headers }),
+          body: JSON.stringify(payload),
+        },
+      );
 
       if (!agmApiResponse.ok) {
         throw new Error(`Error fetching results: ${agmApiResponse.statusText}`);


### PR DESCRIPTION
AGM have now added the `sortBy` querystring param to their API, it would have been nicer if it were in the POST body, like the other filters, but that is not the case and I don't want to waste time going back and forth, so I can accept that for now.

Therefore I have added the querystring to the API fetch query we make e.g. `https://environment-test.data.gov.uk/natural-capital-ecosystem-assessment/search?sortBy=most_relevant`