### PR TITLE
Fixing Geography Details section for Non Spatial search results

### DIFF
--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -412,7 +412,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -231,7 +231,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43039%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40497%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -443,7 +443,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -855,7 +855,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Details route template Document details with data Check status code and
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33815%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38621%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -1339,7 +1339,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         
@@ -1655,7 +1655,7 @@ exports[`Details route template Document details with partial data Check status 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A32881%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37423%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -2512,7 +2512,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
@@ -560,7 +560,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -680,7 +680,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33201%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39745%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -700,7 +700,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -553,7 +553,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Results block template Guided search journey Search results with empty 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37027%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41855%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -2075,7 +2075,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         
@@ -2386,7 +2386,7 @@ exports[`Results block template Guided search journey Search results with error 
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43367%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33643%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -3035,7 +3035,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         
@@ -3346,7 +3346,7 @@ exports[`Results block template Quick search journey Search results with data sh
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36759%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41371%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -5402,7 +5402,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         
@@ -5713,7 +5713,7 @@ exports[`Results block template Quick search journey Search results with empty d
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36389%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42985%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -7554,7 +7554,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         
@@ -7865,7 +7865,7 @@ exports[`Results block template Quick search journey Search results with error s
           
           <li class="govuk-header__navigation-item">
             
-              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43087%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
+              <span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44679%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link'>Login</a></span>
             
           </li>
           
@@ -8514,7 +8514,7 @@ data-module="govuk-service-navigation"
         
         
         <div class="govuk-footer__meta-custom">
-          <p>Version: v1.16.1</p>
+          <p>Version: v1.17.0</p>
         </div>
         
         

--- a/__tests__/utils/getGeographyTabData.spec.ts
+++ b/__tests__/utils/getGeographyTabData.spec.ts
@@ -24,9 +24,7 @@ describe('Geography tab data', () => {
 
     it('should return an empty string when coordinates are not provided', () => {
       const result = getGeographicBoundaryHtml({} as IAccumulatedCoordinates);
-      expect(result).toEqual(
-        '<p>West bounding longitude: <span id="west"></span></p><p>East bounding longitude: <span id="east"></span></p><p>North bounding latitude: <span id="north"></span></p><p>South bounding latitude: <span id="south"></span></p>',
-      );
+      expect(result).toEqual('');
     });
   });
 

--- a/__tests__/utils/validate.spec.ts
+++ b/__tests__/utils/validate.spec.ts
@@ -1,16 +1,31 @@
-import { validateUrl } from '../../src/utils/validate';
+import { validateUrl, validateObjNullValues } from '../../src/utils/validate';
 
-describe('validate url', () => {
-  it.each([
-    ['http://example.com', true],
-    ['https://example.com', true],
-    ['https://www.example.com/path?query=123', true],
-    ['example.com', false],
-    ['htp://example.com', false],
-    ['http://user:password@example.com', false],
-    ['http://example..com', false],
-    ['', false],
-  ])('should validates %s as %s', (url, isValid) => {
-    expect(validateUrl(url)).toStrictEqual(isValid);
+describe('validate', () => {
+  describe('validate url', () => {
+    it.each([
+      ['http://example.com', true],
+      ['https://example.com', true],
+      ['https://www.example.com/path?query=123', true],
+      ['example.com', false],
+      ['htp://example.com', false],
+      ['http://user:password@example.com', false],
+      ['http://example..com', false],
+      ['', false],
+    ])('should validates %s as %s', (url, isValid) => {
+      expect(validateUrl(url)).toStrictEqual(isValid);
+    });
+  });
+
+  describe('validateObjNullValues', () => {
+    it('should return false if object does not contains null value', () => {
+      expect(validateObjNullValues({ a: 'a', b: 'b', c: 'c' })).toStrictEqual(false);
+    });
+    it('should return true if object  contains null value', () => {
+      expect(validateObjNullValues({ a: null, b: null, c: null })).toStrictEqual(true);
+      expect(validateObjNullValues({ a: 'a', b: null, c: 'c' })).toStrictEqual(true);
+    });
+    it('should return false if we pass an empty object', () => {
+      expect(validateObjNullValues({})).toStrictEqual(false);
+    });
   });
 });

--- a/src/utils/getGeographyTabData.ts
+++ b/src/utils/getGeographyTabData.ts
@@ -1,3 +1,4 @@
+import { validateObjNullValues } from './validate';
 import { IAccumulatedCoordinates, IGeography, IGeographyItem } from '../interfaces/searchResponse.interface';
 
 const getVerticalExtentHtml = (verticalRangeObject: { gte?: number; lte?: number }): string => {
@@ -25,8 +26,11 @@ const getSamplingResolution = (distanceObject: { distance?: string }, scale: num
 };
 
 const getGeographicBoundaryHtml = (coordinates: IAccumulatedCoordinates): string => {
-  const { north = '', south = '', east = '', west = '' } = coordinates;
-  return `<p>West bounding longitude: <span id="west">${west}</span></p><p>East bounding longitude: <span id="east">${east}</span></p><p>North bounding latitude: <span id="north">${north}</span></p><p>South bounding latitude: <span id="south">${south}</span></p>`;
+  if (Object.keys(coordinates).length > 0) {
+    const { north = '', south = '', east = '', west = '' } = coordinates;
+    return `<p>West bounding longitude: <span id="west">${west}</span></p><p>East bounding longitude: <span id="east">${east}</span></p><p>North bounding latitude: <span id="north">${north}</span></p><p>South bounding latitude: <span id="south">${south}</span></p>`;
+  }
+  return '';
 };
 
 const getGeographicMarkers = (location: string | string[]): string => {
@@ -47,19 +51,17 @@ const getGeographicMarkers = (location: string | string[]): string => {
 };
 
 const getGeographicLocations = (geographicBoundary) => {
-  if (geographicBoundary && Object.keys(geographicBoundary).length) {
-    if (geographicBoundary && Object.keys(geographicBoundary).length) {
-      const coordinates = {
-        north: geographicBoundary.bboxNorthLat,
-        south: geographicBoundary.bboxSouthLat,
-        east: geographicBoundary.bboxEastLong,
-        west: geographicBoundary.bboxWestLong,
-      };
-      const { north, south, east, west } = coordinates;
-      const latitude = south - 5.0 + (north + 5.0 - (south - 5.0)) / 2;
-      const longitude = west - 5.0 + (east + 5.0 - (west - 5.0)) / 2;
-      return { coordinates, center: `${longitude},${latitude}` };
-    }
+  if (geographicBoundary && Object.keys(geographicBoundary).length && !validateObjNullValues(geographicBoundary)) {
+    const coordinates = {
+      north: geographicBoundary.bboxNorthLat,
+      south: geographicBoundary.bboxSouthLat,
+      east: geographicBoundary.bboxEastLong,
+      west: geographicBoundary.bboxWestLong,
+    };
+    const { north, south, east, west } = coordinates;
+    const latitude = south - 5.0 + (north + 5.0 - (south - 5.0)) / 2;
+    const longitude = west - 5.0 + (east + 5.0 - (west - 5.0)) / 2;
+    return { coordinates, center: `${longitude},${latitude}` };
   }
   return {};
 };

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,4 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const validateUrl = (url: string) => {
   const regex = /^(https?):\/\/([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,6}(:\d+)?(\/[^\s]*)?$/;
   return regex.test(url);
+};
+
+export const validateObjNullValues = (obj: Record<string, any>): boolean => {
+  for (const key in obj) {
+    if (Object.hasOwn(obj, key) && obj[key] === null) {
+      return true;
+    }
+  }
+  return false;
 };


### PR DESCRIPTION
### What one thing this PR does?
This will fix the issue, when we view the Geography Details section under more info for Non Spatial search results

### How do these changes look like?
![Screenshot 2025-03-24 170423](https://github.com/user-attachments/assets/60c82468-8865-4f34-b8be-33296ae6ab9d)

### Dev-tested in

1. Local environment

- [Search Result More Info](http://localhost:3000/natural-capital-ecosystem-assessment/search/c0395a9b-7705-41a7-912d-b77153b63dde?dt=non-spatial&date-before=&date-after=&licence=&keywords=&scope=all&q=disease&rpp=20&srt=most_relevant&jry=qs&pg=1#geography)
