### PR TITLE
NCEA-266 Search results seem to be run twice + NCEA-269 Typo on Detail page > Geography tab > Vertical extent

### DIFF
--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -872,37 +872,35 @@ const getMapResultsOnPageload = async (fitToMapExtentFlag) => {
   const noSpatialDataSpan = document.getElementById(noSpatialDataId);
   const viewResultsSpan = document.getElementById(viewResultsId);
   const mapContainerDiv = document.getElementById(mapContainerId);
-  const searchResults = window?.searchResults ?? {};
+  const searchResults = window.searchResults;
+  const mapResultsData = filterMapResults(searchResults.items);
 
-  if (Object.keys(searchResults).length !== 0) {
-    const mapResultsData = filterMapResults(searchResults.items);
-    mapResultsCount.textContent = mapResultsData.length;
+  mapResultsCount.textContent = mapResultsData.length;
 
-    if (mapResultsData.length === 0) {
-      mapContainerDiv.classList.add('disabled');
-      noSpatialDataSpan.classList.remove('display-none');
-      viewResultsSpan.classList.add('display-none');
-    } else {
-      mapResultsButton.removeAttribute('disabled');
-      mapContainerDiv.classList.remove('disabled');
-      noSpatialDataSpan.classList.add('display-none');
-      viewResultsSpan.classList.remove('display-none');
-    }
-    const boundingBoxInfo = document.getElementById('defra-bounding-box-info');
-
-    if (boundingBoxInfo && searchResults.total > maxCountForBoundingBoxInfo) {
-      boundingBoxInfo.style.display = 'block';
-    } else {
-      boundingBoxInfo.style.display = 'none';
-    }
-    mapResults = mapResultsData;
-    polygonFeatureData.length = 0;
-    setTimeout(() => {
-      drawBoundingBoxWithMarker(fitToMapExtentFlag, true);
-    }, 100);
-    attachBoundingBoxToggleListener();
-    // don't need to handle the `else` cases anymore as it start disabled by default
+  if (mapResultsData.length === 0) {
+    mapContainerDiv.classList.add('disabled');
+    noSpatialDataSpan.classList.remove('display-none');
+    viewResultsSpan.classList.add('display-none');
+  } else {
+    mapResultsButton.removeAttribute('disabled');
+    mapContainerDiv.classList.remove('disabled');
+    noSpatialDataSpan.classList.add('display-none');
+    viewResultsSpan.classList.remove('display-none');
   }
+  const boundingBoxInfo = document.getElementById('defra-bounding-box-info');
+
+  if (boundingBoxInfo && searchResults.total > maxCountForBoundingBoxInfo) {
+    boundingBoxInfo.style.display = 'block';
+  } else {
+    boundingBoxInfo.style.display = 'none';
+  }
+  mapResults = mapResultsData;
+  polygonFeatureData.length = 0;
+  setTimeout(() => {
+    drawBoundingBoxWithMarker(fitToMapExtentFlag, true);
+  }, 100);
+  attachBoundingBoxToggleListener();
+  // don't need to handle the `else` cases anymore as it start disabled by default
 };
 
 const getMapFilters = async (path) => {

--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -866,6 +866,45 @@ const getMapResults = async (path, fitToMapExtentFlag) => {
   }
 };
 
+const getMapResultsOnPageload = async (fitToMapExtentFlag) => {
+  const mapResultsButton = document.getElementById(mapResultsButtonId);
+  const mapResultsCount = document.getElementById(mapResultsCountId);
+  const noSpatialDataSpan = document.getElementById(noSpatialDataId);
+  const viewResultsSpan = document.getElementById(viewResultsId);
+  const mapContainerDiv = document.getElementById(mapContainerId);
+  const searchResults = window?.searchResults ?? {};
+
+  if (Object.keys(searchResults).length !== 0) {
+    const mapResultsData = filterMapResults(searchResults.items);
+    mapResultsCount.textContent = mapResultsData.length;
+
+    if (mapResultsData.length === 0) {
+      mapContainerDiv.classList.add('disabled');
+      noSpatialDataSpan.classList.remove('display-none');
+      viewResultsSpan.classList.add('display-none');
+    } else {
+      mapResultsButton.removeAttribute('disabled');
+      mapContainerDiv.classList.remove('disabled');
+      noSpatialDataSpan.classList.add('display-none');
+      viewResultsSpan.classList.remove('display-none');
+    }
+    const boundingBoxInfo = document.getElementById('defra-bounding-box-info');
+
+    if (boundingBoxInfo && searchResults.total > maxCountForBoundingBoxInfo) {
+      boundingBoxInfo.style.display = 'block';
+    } else {
+      boundingBoxInfo.style.display = 'none';
+    }
+    mapResults = mapResultsData;
+    polygonFeatureData.length = 0;
+    setTimeout(() => {
+      drawBoundingBoxWithMarker(fitToMapExtentFlag, true);
+    }, 100);
+    attachBoundingBoxToggleListener();
+    // don't need to handle the `else` cases anymore as it start disabled by default
+  }
+};
+
 const getMapFilters = async (path) => {
   const response = await invokeAjaxCall(path, {}, false, 'GET');
   if (response && response?.status === responseSuccessStatusCode) {
@@ -1134,7 +1173,7 @@ document.addEventListener('DOMContentLoaded', () => {
         geographyTabListener();
       }, timeout);
     } else if (isMapResultsScreen) {
-      invokeMapResults(true);
+      getMapResultsOnPageload(true);
       invokeMapFilters();
       exitMapEventListener();
       attachCluserListCloseListener();

--- a/src/controllers/web/SearchResultsController.ts
+++ b/src/controllers/web/SearchResultsController.ts
@@ -44,7 +44,7 @@ const SearchResultsController = {
         payload,
         request.auth.credentials as Credentials,
         processedDspFilterOptions,
-        false,
+        true,
         // isQuickSearchJourney, // TODO: We may need to add this back in, which is why I've left it.
       );
 
@@ -75,6 +75,7 @@ const SearchResultsController = {
         pageTitle: pageTitles.results,
         quickSearchFID,
         searchResults: pagedSearchResults,
+        totalSearchResults: searchResults,
         hasError: false,
         isQuickSearchJourney,
         paginationItems,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -188,7 +188,7 @@ export const detailsTabOptions: TabOptions = {
     'Geographic locations': 'geographicLocations',
     'Geographic boundary': 'geographicBoundaryHtml',
     map: 'geographicBoundary',
-    'Vertical extent<br /><span>(Meters above sea level)</span>': 'verticalExtent',
+    'Vertical extent<br /><span>(Metres above sea level)</span>': 'verticalExtent',
     'Spatial resolution': 'samplingResolution',
   },
   license: {

--- a/src/views/screens/results/template.njk
+++ b/src/views/screens/results/template.njk
@@ -40,6 +40,7 @@
     <script src="{{ assetPath }}/scripts/ol.js"></script>
     <script>
       var isViewMapResults = true;
+      window.searchResults = {{ totalSearchResults | dump | safe }}
     </script>
     <script type="module" src="{{ assetPath }}/scripts/location.js"></script>
     <script type="module" src="{{ assetPath }}/scripts/filters.js"></script>


### PR DESCRIPTION
### What one thing this PR does?

In this PR, I have fixed the issue related to search results API calling be run run twice. Now on search page load, i will fetch the results from the search result API call.

A sample one-liner about this task.

### Task details

- [NCEA-266 - Search results seem to be run twice](https://dsp-support.atlassian.net/browse/NCEA-266)
- [NCEA-269 - NCEA-269 Typo on Detail page > Geography tab > Vertical extent](https://dsp-support.atlassian.net/browse/NCEA-269)

### How do these changes look like?
![Screenshot 2025-04-04 111059](https://github.com/user-attachments/assets/9fa8d58a-8c5c-4e85-8f69-44e94dccdde2)

### Dev-tested in

1. Local environment

- [Search Results](http://localhost:3000/natural-capital-ecosystem-assessment/search?q=disease&jry=qs&pg=1&rpp=20&srt=most_relevant)
