### PR TITLE
NCEA-270 Replace mocks for Natural capital

### DIFF
--- a/__tests__/utils/getNaturalCapitalTab.spec.ts
+++ b/__tests__/utils/getNaturalCapitalTab.spec.ts
@@ -1,4 +1,8 @@
-import { getNaturalTab, generateClassifierTable } from '../../src/utils/getNaturalCapitalTab';
+import {
+  getNaturalTab,
+  generateClassifierTable,
+  transformNceaClassifierObj,
+} from '../../src/utils/getNaturalCapitalTab';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 import { naturalTabStaticData } from '../../src/utils/constants';
 
@@ -8,7 +12,7 @@ describe('getNaturalTab', () => {
 
     expect(result.Natural_capital_title).toStrictEqual(naturalTabStaticData.title);
     expect(result.Natural_capital_description).toStrictEqual(naturalTabStaticData.description);
-    expect(result.Natural_capital_displayData).toContain('<table class="details-table-full">');
+    expect(result.Natural_capital_displayData).toContain('');
   });
 });
 
@@ -78,5 +82,43 @@ describe('generateClassifierTable', () => {
     expect(result).toContain('<td>Theme 1</td>');
     expect(result).toContain('<td>Terrestrial and freshwater habitats</td>');
     expect(result).not.toContain('<th width="35%">Subcategory</th>');
+  });
+
+  it('should validate the transformNceaClassifierObj and reture the expected output', () => {
+    const input = {
+      naturalCapitalTheme: ['lvl1_003', 'lvl1_002', 'lvl1_001'],
+      naturalCapitalCategory: ['lvl2_004', 'lvl2_008'],
+      naturalCapitalSubCategory: ['lvl3_059'],
+    };
+
+    const output = {
+      naturalCapitalThemes: [
+        {
+          id: 'lvl1_003',
+          name: 'lvl1_003',
+          naturalCapitalCategory: [
+            { id: 'lvl2_004', name: 'lvl2_004', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+            { id: 'lvl2_008', name: 'lvl2_008', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+          ],
+        },
+        {
+          id: 'lvl1_002',
+          name: 'lvl1_002',
+          naturalCapitalCategory: [
+            { id: 'lvl2_004', name: 'lvl2_004', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+            { id: 'lvl2_008', name: 'lvl2_008', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+          ],
+        },
+        {
+          id: 'lvl1_001',
+          name: 'lvl1_001',
+          naturalCapitalCategory: [
+            { id: 'lvl2_004', name: 'lvl2_004', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+            { id: 'lvl2_008', name: 'lvl2_008', naturalCapitalSubCategory: [{ id: 'lvl3_059', name: 'lvl3_059' }] },
+          ],
+        },
+      ],
+    };
+    expect(transformNceaClassifierObj(input)).toEqual(output);
   });
 });

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -138,7 +138,6 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
 
 export const formatSearchResponse = (payload: IMoreInfoSearchItem) => {
   const resourceUrl = getResourceLocatorURL(payload?.resources[0]?.url ?? '');
-  console.log('payload', payload);
   return {
     id: payload?.id,
     title: payload?.title ?? '',

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -138,6 +138,7 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
 
 export const formatSearchResponse = (payload: IMoreInfoSearchItem) => {
   const resourceUrl = getResourceLocatorURL(payload?.resources[0]?.url ?? '');
+  console.log('payload', payload);
   return {
     id: payload?.id,
     title: payload?.title ?? '',

--- a/src/utils/getNaturalCapitalTab.ts
+++ b/src/utils/getNaturalCapitalTab.ts
@@ -6,7 +6,7 @@ import {
   NaturalCapitalSubCategory,
   NaturalCapitalTableItems,
 } from '../interfaces/searchResponse.interface';
-import { naturalTabStaticData, nceaClassifiersMockTableData } from '../utils/constants';
+import { naturalTabStaticData } from '../utils/constants';
 
 export const generateClassifierTable = (data: NaturalCapitalTableItems[]): string => {
   if (!Array.isArray(data) || data.length === 0) {
@@ -120,13 +120,34 @@ const createRow = (
     </tr>
   `;
 };
+// temp added the transform function, will remove it, once get the update from API
+export const transformNceaClassifierObj = (nceaClassfiersObj) => {
+  if (nceaClassfiersObj?.naturalCapitalTheme?.length > 0) {
+    return {
+      naturalCapitalThemes: nceaClassfiersObj?.naturalCapitalTheme?.map((theme) => ({
+        id: theme,
+        name: theme,
+        naturalCapitalCategory: nceaClassfiersObj?.naturalCapitalCategory?.map((category) => ({
+          id: category,
+          name: category,
+          naturalCapitalSubCategory: nceaClassfiersObj?.naturalCapitalSubCategory?.map((subCategory) => ({
+            id: subCategory,
+            name: subCategory,
+          })),
+        })),
+      })),
+    };
+  }
+  return {
+    naturalCapitalThemes: [],
+  };
+};
 
 const getNaturalTab = (payload): INatural => ({
   Natural_capital_title: naturalTabStaticData.title,
   Natural_capital_description: naturalTabStaticData.description,
   Natural_capital_displayData: generateClassifierTable(
-    payload?.nceaClassifiers?.naturalCapitalThemes ??
-      nceaClassifiersMockTableData?.nceaClassifiers?.naturalCapitalThemes,
+    transformNceaClassifierObj(payload?.nceaClassfiers).naturalCapitalThemes,
   ),
 });
 


### PR DESCRIPTION
### What one thing this PR does?

In this PR, I have added the transform function which will convert into the expected classifier table output to generate the table for Theme, Category and Sub Category

### Task details

- [NCEA-270 - Replace mocks for Natural capital](https://dsp-support.atlassian.net/browse/NCEA-270)

### How do these changes look like?

| ![name of the screengrab](URL) |

With natural capital theme data
![Screenshot 2025-04-04 121727](https://github.com/user-attachments/assets/960f1883-d3fc-4ab3-9dab-121fd19ad9fd)

With Empty array of response for Natural Classifiers

![Screenshot 2025-04-04 144137](https://github.com/user-attachments/assets/2b40ee99-0dd9-4ce2-a6dd-8824059f8b2a)


### Dev-tested in

1. Local environment

- [More Info Natual Tab](http://localhost:4000/natural-capital-ecosystem-assessment/search/ee218908-f1d4-4c30-a325-f49e42809a88?jry=gs&level=1&parent%5B%5D=lvl1_001&cnt=2&pg=1&rpp=20&srt=most_relevant#natural)
