### PR TITLE
fix(blogs): Ensure blog fetching uses IPv4

### DIFF
--- a/src/utils/getFeedsData.ts
+++ b/src/utils/getFeedsData.ts
@@ -1,9 +1,15 @@
+import https from 'https';
+
 import { format, parseISO } from 'date-fns';
 import Parser from 'rss-parser';
 
 import { Feed, FeedArticle } from '../interfaces/feeds.interface';
 
-const parser = new Parser();
+const parser = new Parser({
+  requestOptions: {
+    agent: new https.Agent({ family: 4 }),
+  },
+});
 
 const isValidArticle = (item): item is FeedArticle =>
   typeof item.title === 'string' &&


### PR DESCRIPTION
We experienced a problem fetching blogs on our local DEV VMs, where the requests consistently failed. However we did not experience this when the app is deployed in the `test` environment.

After some googling it seems it is NodeJS preferring `IPv6` over `IPv4`. This still doesn't explain why it works in `test` though, however having configured the **RSS Parser** to use `IPv4` only, I am getting blogs again on my local setup.

Ticket: https://dsp-support.atlassian.net/browse/NCEA-276