### PR TITLE
NCEA-280 Single Record view - UI to lookup human readable names for themes, categories and sub-categories

### DIFF
--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -289,6 +289,7 @@ export interface IGeographyItem {
 export interface INaturalItem {
   title?: string;
   abstract?: string;
+  nceaClassfiers?: NceaClassifier;
 }
 
 export interface IMoreInfoSearchItem extends IGeographyItem, IQualityItem, IGeneralItem, IAccessItem {

--- a/src/utils/getNaturalCapitalTab.ts
+++ b/src/utils/getNaturalCapitalTab.ts
@@ -3,12 +3,12 @@
 import {
   Category,
   INatural,
+  INaturalItem,
   NaturalCapitalCategory,
   NaturalCapitalSubCategory,
   NaturalCapitalTableItems,
   NaturalCapitalTheme,
   OutputCategory,
-  OutputSubCategory,
   OutputTheme,
   SubCategory,
 } from '../interfaces/searchResponse.interface';
@@ -151,30 +151,29 @@ export const transformNceaClassifierObj = (nceaClassfiersObj, vocabularyData) =>
             const category = findCategory(theme, categoryCode);
             if (!category) return;
 
-            const subCategories: OutputSubCategory[] = nceaClassfiersObj.naturalCapitalSubCategory
-              .map((subCode: string) => {
-                const subCategory = findSubCategory(category, subCode);
-                return subCategory ? { id: subCategory.code, name: subCategory.name } : undefined;
-              })
-              .filter((subCategory: string) => subCategory);
-
-            if (subCategories.length > 0) {
-              return {
-                id: category.code,
-                name: category.name,
-                naturalCapitalSubCategory: subCategories,
-              };
+            let subCategories = [];
+            if ((category.classifiers ?? []).length > 0) {
+              subCategories = nceaClassfiersObj.naturalCapitalSubCategory
+                .map((subCode: string) => {
+                  const subCategory = findSubCategory(category, subCode);
+                  return subCategory ? { id: subCategory.code, name: subCategory.name } : undefined;
+                })
+                .filter((subCategory: string) => subCategory);
             }
+            return {
+              id: category.code,
+              name: category.name,
+              ...(subCategories.length > 0 ? { naturalCapitalSubCategory: subCategories } : {}),
+            };
           })
           .filter((category: string) => category);
 
-        if (categories.length > 0) {
-          return {
-            id: theme.code,
-            name: theme.name,
-            naturalCapitalCategory: categories,
-          };
-        }
+        return {
+          id: theme.code,
+          name: theme.name,
+          ...(categories.length > 0 ? { naturalCapitalCategory: categories } : {}),
+          naturalCapitalCategory: categories,
+        };
       })
       .filter((theme: string) => theme);
 
@@ -187,7 +186,7 @@ export const transformNceaClassifierObj = (nceaClassfiersObj, vocabularyData) =>
   };
 };
 
-const getNaturalTab = (payload, vocabularyData: NaturalCapitalTheme[]): INatural => ({
+const getNaturalTab = (payload: INaturalItem, vocabularyData: NaturalCapitalTheme[]): INatural => ({
   Natural_capital_title: naturalTabStaticData.title,
   Natural_capital_description: naturalTabStaticData.description,
   Natural_capital_displayData: generateClassifierTable(


### PR DESCRIPTION
### What one thing this PR does?
In this PR, I have fix the issue to display Theme and Category, if there is no Sub-Category. It will also display theme, if there is no category and subcategory

### How do these changes look like?
![Screenshot from 2025-04-11 14-08-20](https://github.com/user-attachments/assets/9429215b-9425-4c36-84e0-7180663ac11b)
![Screenshot from 2025-04-11 14-07-58](https://github.com/user-attachments/assets/23f7e9e7-d673-4ab5-89f1-eb685a2a1b18)
![Screenshot from 2025-04-11 14-07-23](https://github.com/user-attachments/assets/d12eea97-8290-4700-af86-ce3d067ee6bc)


### Task details

- [NCEA-280 - Single Record view - UI to lookup human readable names for themes,categories and sub-categories](https://dsp-support.atlassian.net/browse/NCEA-280)
