### PR TITLE
NCEA-191 Added the Dataset reference date in Search Result Section

### DIFF
--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
     
   </head>

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
     
   </head>
@@ -233,7 +233,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41529%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38299%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
     
   </head>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`Details route template Document details with data Check status code and
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
 
@@ -236,7 +236,7 @@ exports[`Details route template Document details with data Check status code and
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33837%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45079%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -1699,7 +1699,7 @@ exports[`Details route template Document details with partial data Check status 
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
 
@@ -1908,7 +1908,7 @@ exports[`Details route template Document details with partial data Check status 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A32861%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41723%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`Feeds Screen Feeds > Sanpshot verification should match the Feeds scree
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
     
   </head>

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
 

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
 
@@ -236,7 +236,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41007%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45403%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
     
   </head>

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`Results block template Guided search journey Search results with empty 
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
   
@@ -236,7 +236,7 @@ exports[`Results block template Guided search journey Search results with empty 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33273%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40373%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -621,13 +621,13 @@ exports[`Results block template Guided search journey Search results with empty 
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
         <label class="govuk-label govuk-radios__label" for="scope-search_results">
-          NCEA Metadata Only
+          NCEA data
         </label>
       </div>
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
         <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-          DSP and NCEA Metadata
+          All natural capital data
         </label>
       </div>
     </div>
@@ -2264,7 +2264,7 @@ exports[`Results block template Guided search journey Search results with error 
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
   
@@ -2473,7 +2473,7 @@ exports[`Results block template Guided search journey Search results with error 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45503%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40859%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -2858,13 +2858,13 @@ exports[`Results block template Guided search journey Search results with error 
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
         <label class="govuk-label govuk-radios__label" for="scope-">
-          NCEA Metadata Only
+          NCEA data
         </label>
       </div>
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
         <label class="govuk-label govuk-radios__label" for="scope-all-">
-          DSP and NCEA Metadata
+          All natural capital data
         </label>
       </div>
     </div>
@@ -3309,7 +3309,7 @@ exports[`Results block template Quick search journey Search results with data sh
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
   
@@ -3518,7 +3518,7 @@ exports[`Results block template Quick search journey Search results with data sh
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43019%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39689%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -3903,13 +3903,13 @@ exports[`Results block template Quick search journey Search results with data sh
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
         <label class="govuk-label govuk-radios__label" for="scope-search_results">
-          NCEA Metadata Only
+          NCEA data
         </label>
       </div>
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
         <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-          DSP and NCEA Metadata
+          All natural capital data
         </label>
       </div>
     </div>
@@ -5411,31 +5411,34 @@ exports[`Results block template Quick search journey Search results with data sh
             <span class='search-result__parameter-value search-result__published-value'>Organization 1</span>
           </div>
         
-        <div class='search-result__parameter'>
-          <span class='search-result__parameter-label search-result__study-label'>Study period</span>
-          <span class='search-result__parameter-value search-result__study-value'>
-            <span class='start'>
-              
-                04 Jan 1960
-              
-            </span>
-            <span>to</span>
-            <span class='end'>
-              
-                <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
+        
+        
+          <div class='search-result__parameter'>
+            <span class='search-result__parameter-label search-result__study-label'>Study period</span>
+            <span class='search-result__parameter-value search-result__study-value'>
+              <span class='start'>
+                
+                  04 Jan 1960
+                
+              </span>
+              <span>to</span>
+              <span class='end'>
+                
+                  <strong class="govuk-tag govuk-tag--grey tab-content-value__not-provided">
   Unavailable
 </strong>
 
-              
+                
+              </span>
             </span>
-          </span>
-        </div>
+          </div>
+        
         <p class='search-result__content'>
           Content 1
         </p>
 
         
-        
+
         <div class='govuk-button-group search-result__button-group'>
           
           
@@ -5460,28 +5463,31 @@ exports[`Results block template Quick search journey Search results with data sh
             <span class='search-result__parameter-value search-result__published-value'>Organization 2</span>
           </div>
         
-        <div class='search-result__parameter'>
-          <span class='search-result__parameter-label search-result__study-label'>Study period</span>
-          <span class='search-result__parameter-value search-result__study-value'>
-            <span class='start'>
-              
-                04 Jan 1950
-              
+        
+        
+          <div class='search-result__parameter'>
+            <span class='search-result__parameter-label search-result__study-label'>Study period</span>
+            <span class='search-result__parameter-value search-result__study-value'>
+              <span class='start'>
+                
+                  04 Jan 1950
+                
+              </span>
+              <span>to</span>
+              <span class='end'>
+                
+                  12 Jan 2009
+                
+              </span>
             </span>
-            <span>to</span>
-            <span class='end'>
-              
-                12 Jan 2009
-              
-            </span>
-          </span>
-        </div>
+          </div>
+        
         <p class='search-result__content'>
           Content 2
         </p>
 
         
-        
+
         <div class='govuk-button-group search-result__button-group'>
           
           
@@ -5767,7 +5773,7 @@ exports[`Results block template Quick search journey Search results with empty d
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
   
@@ -5976,7 +5982,7 @@ exports[`Results block template Quick search journey Search results with empty d
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36019%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45343%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -6361,13 +6367,13 @@ exports[`Results block template Quick search journey Search results with empty d
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-search_results"  name="scope" type="radio" value="ncea">
         <label class="govuk-label govuk-radios__label" for="scope-search_results">
-          NCEA Metadata Only
+          NCEA data
         </label>
       </div>
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-all-search_results" checked name="scope" type="radio" value="all">
         <label class="govuk-label govuk-radios__label" for="scope-all-search_results">
-          DSP and NCEA Metadata
+          All natural capital data
         </label>
       </div>
     </div>
@@ -8004,7 +8010,7 @@ exports[`Results block template Quick search journey Search results with error s
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <meta name="version" content="v1.22.0">
+  <meta name="version" content="v1.23.0">
 
   <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/ol.css">
   
@@ -8213,7 +8219,7 @@ exports[`Results block template Quick search journey Search results with error s
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42375%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38779%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -8598,13 +8604,13 @@ exports[`Results block template Quick search journey Search results with error s
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-"  name="" type="radio" value="">
         <label class="govuk-label govuk-radios__label" for="scope-">
-          NCEA Metadata Only
+          NCEA data
         </label>
       </div>
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="scope-all-" checked name="" type="radio" value="">
         <label class="govuk-label govuk-radios__label" for="scope-all-">
-          DSP and NCEA Metadata
+          All natural capital data
         </label>
       </div>
     </div>

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -13,6 +13,7 @@ export interface IBaseItem {
   abstract?: string;
   displayDataSetReferenceDate?: boolean;
   dataSetReferenceDate?: string;
+  dataSetReferenceLabel?: string;
 }
 
 export interface IGeneralItem {

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -11,6 +11,8 @@ export interface IBaseItem {
   organisationName?: string;
   resourceType?: string[];
   abstract?: string;
+  displayDataSetReferenceDate?: boolean;
+  dataSetReferenceDate?: string;
 }
 
 export interface IGeneralItem {
@@ -112,7 +114,7 @@ export interface IQualityItem {
   metadataDate?: string;
   lineage?: string;
   additionalInformation?: null | undefined | string;
-  recordDates: IRecordDates;
+  datasetReferenceDate: IDataSetReferenceDate;
 }
 
 export interface IQuality {
@@ -179,7 +181,7 @@ export type IOtherSearchItem = IGeneralItem &
   IGovernance;
 
 export interface ISearchItem extends IBaseItem {
-  [key: string]: IGovernance | string | number | undefined | string[] | IAccumulatedCoordinates;
+  [key: string]: IGovernance | string | number | undefined | boolean | string[] | IAccumulatedCoordinates;
 }
 
 export interface TabbedItem {
@@ -208,6 +210,13 @@ export interface IResource {
   availableLanguages: string[];
 }
 
+interface IDataSetReferenceDate {
+  publication?: string;
+  creation: string;
+  revision: string;
+  metadata?: null | undefined | string;
+}
+
 export interface ISearchResult {
   searchScore: number;
   id: string;
@@ -228,6 +237,7 @@ export interface ISearchResult {
   resource?: IResource;
   organisation?: string;
   nceaContribution: string;
+  datasetReferenceDate: IDataSetReferenceDate;
 }
 
 export interface ISearchResponse {

--- a/src/services/handlers/mocks/more-info-response.ts
+++ b/src/services/handlers/mocks/more-info-response.ts
@@ -310,8 +310,3 @@ export const MOCK_VOCABULARY_DATA = [
     ],
   },
 ];
-
-export const MOCK_SEARCH_RESULTS = {
-  results: [MORE_INFO_MOCK_DATA],
-  totalDocumentCount: 1,
-};

--- a/src/services/handlers/mocks/more-info-response.ts
+++ b/src/services/handlers/mocks/more-info-response.ts
@@ -107,6 +107,12 @@ export const MORE_INFO_MOCK_DATA = {
     frequencyOfUpdate: 'unknown',
   },
   nceaContribution: '',
+  datasetReferenceDate: {
+    metadata: null,
+    publication: '2017-02-11T00:00:00Z',
+    revision: '2024-06-10T18:41:32Z',
+    creation: '2023-03-10T15:10:20Z',
+  },
 };
 
 export const MOCK_VOCABULARY_DATA = [
@@ -304,3 +310,8 @@ export const MOCK_VOCABULARY_DATA = [
     ],
   },
 ];
+
+export const MOCK_SEARCH_RESULTS = {
+  results: [MORE_INFO_MOCK_DATA],
+  totalDocumentCount: 1,
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -405,3 +405,6 @@ export const nceaClassifiersMockTableData = {
     ],
   },
 };
+export const DATASET_PUBLICATION_DATE_LABEL = 'Dataset publication date';
+export const DATASET_REVISION_DATE_LABEL = 'Dataset revision date';
+export const DATASET_CREATION_DATE_LABEL = 'Dataset creation date';

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -10,6 +10,7 @@ import { getGovernanceTabData } from './getGovernanceTab';
 import { getLicenseTabData } from './getLicenseTabData';
 import { getNaturalTab } from './getNaturalCapitalTab';
 import { getQualityTabData } from './getQualityTabData';
+import { isEmpty } from './isEmpty';
 import { setNceaContribution } from './nceaContribution';
 import { toggleContent } from './toggleContent';
 import { validateUrl } from './validate';
@@ -96,7 +97,19 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
       publishedBy: result?.organisation ?? '',
       resourceType: ['dataset'],
       nceaContribution: setNceaContribution(result?.nceaContribution),
+      displayDataSetReferenceDate: false,
+      dataSetReferenceDate: '',
     };
+
+    if (isEmpty(searchResponse.studyPeriodStart) && isEmpty(searchResponse.studyPeriodEnd)) {
+      const dataSetReferenceDate = new Date(
+        result.datasetReferenceDate.publication ??
+          result.datasetReferenceDate.revision ??
+          result.datasetReferenceDate.creation,
+      );
+      searchResponse.displayDataSetReferenceDate = true;
+      searchResponse.dataSetReferenceDate = dataSetReferenceDate ? format(dataSetReferenceDate, DATE_FORMAT) : '';
+    }
 
     if (isMapResults && result?.mapping) {
       const envelope = result?.mapping;

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -2,6 +2,7 @@
 import { center } from '@turf/turf';
 import { format } from 'date-fns';
 
+import { DATASET_CREATION_DATE_LABEL, DATASET_PUBLICATION_DATE_LABEL, DATASET_REVISION_DATE_LABEL } from './constants';
 import { formatDate, getYear } from './dates';
 import { getAccessTabData } from './getAccessTabData';
 import { getGeneralTabData } from './getGeneralTabData';
@@ -99,14 +100,22 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
       nceaContribution: setNceaContribution(result?.nceaContribution),
       displayDataSetReferenceDate: false,
       dataSetReferenceDate: '',
+      dataSetReferenceLabel: '',
     };
 
     if (isEmpty(searchResponse.studyPeriodStart) && isEmpty(searchResponse.studyPeriodEnd)) {
-      const dataSetReferenceDate = new Date(
-        result.datasetReferenceDate.publication ??
-          result.datasetReferenceDate.revision ??
-          result.datasetReferenceDate.creation,
-      );
+      const dataSetPublicationDate = result.datasetReferenceDate.publication;
+      const dataSetRevisionDate = result.datasetReferenceDate.revision;
+      const dataSetCreationDate = result.datasetReferenceDate.creation;
+
+      if (dataSetPublicationDate) {
+        searchResponse.dataSetReferenceLabel = DATASET_PUBLICATION_DATE_LABEL;
+      } else if (dataSetRevisionDate) {
+        searchResponse.dataSetReferenceLabel = DATASET_REVISION_DATE_LABEL;
+      } else {
+        searchResponse.dataSetReferenceLabel = DATASET_CREATION_DATE_LABEL;
+      }
+      const dataSetReferenceDate = new Date(dataSetPublicationDate ?? dataSetRevisionDate ?? dataSetCreationDate);
       searchResponse.displayDataSetReferenceDate = true;
       searchResponse.dataSetReferenceDate = dataSetReferenceDate ? format(dataSetReferenceDate, DATE_FORMAT) : '';
     }

--- a/src/utils/getQualityTabData.ts
+++ b/src/utils/getQualityTabData.ts
@@ -42,10 +42,10 @@ const getRecordsDates = (data: string): string => {
 };
 
 const getQualityTabData = (payload: IQualityItem): IQuality => ({
-  publicationInformation: getRecordsDates(payload?.recordDates?.publication ?? ''),
-  creationInformation: getRecordsDates(payload?.recordDates?.creation ?? ''),
-  revisionInformation: getRecordsDates(payload?.recordDates?.revision ?? ''),
-  metadataDate: getRecordsDates(payload?.recordDates?.metadata ?? ''),
+  publicationInformation: getRecordsDates(payload?.datasetReferenceDate?.publication ?? ''),
+  creationInformation: getRecordsDates(payload?.datasetReferenceDate?.creation ?? ''),
+  revisionInformation: getRecordsDates(payload?.datasetReferenceDate?.revision ?? ''),
+  metadataDate: getRecordsDates(payload?.datasetReferenceDate?.metadata ?? ''),
   lineage: payload?.lineage ?? '',
   conformity: '', // Need to test this, once data is available from AGM side
   additionalInformation: '', // Need to test this, once data is available from AGM side

--- a/src/views/partials/results/summary.njk
+++ b/src/views/partials/results/summary.njk
@@ -99,32 +99,40 @@
             <span class='search-result__parameter-value search-result__published-value'>{{ item.publishedBy }}</span>
           </div>
         {% endif %}
-        <div class='search-result__parameter'>
-          <span class='search-result__parameter-label search-result__study-label'>Study period</span>
-          <span class='search-result__parameter-value search-result__study-value'>
-            <span class='start'>
-              {% if item.studyPeriodStart %}
-                {{ item.studyPeriodStart }}
-              {% else %}
-                {{govukTag({
-                  text: "Unavailable",
-                  classes: "govuk-tag--grey tab-content-value__not-provided"
-                })}}
-              {% endif %}
+        {% if item.displayDataSetReferenceDate %}
+          <div class='search-result__parameter'>
+            <span class='search-result__parameter-label search-result__published-label'>Dataset reference date</span>
+            <span class='search-result__parameter-value search-result__published-value'>{{ item.dataSetReferenceDate }}</span>
+          </div>
+        {% endif %}
+        {% if not item.displayDataSetReferenceDate %}
+          <div class='search-result__parameter'>
+            <span class='search-result__parameter-label search-result__study-label'>Study period</span>
+            <span class='search-result__parameter-value search-result__study-value'>
+              <span class='start'>
+                {% if item.studyPeriodStart %}
+                  {{ item.studyPeriodStart }}
+                {% else %}
+                  {{govukTag({
+                    text: "Unavailable",
+                    classes: "govuk-tag--grey tab-content-value__not-provided"
+                  })}}
+                {% endif %}
+              </span>
+              <span>to</span>
+              <span class='end'>
+                {% if item.studyPeriodEnd %}
+                  {{ item.studyPeriodEnd }}
+                {% else %}
+                  {{govukTag({
+                    text: "Unavailable",
+                    classes: "govuk-tag--grey tab-content-value__not-provided"
+                  })}}
+                {% endif %}
+              </span>
             </span>
-            <span>to</span>
-            <span class='end'>
-              {% if item.studyPeriodEnd %}
-                {{ item.studyPeriodEnd }}
-              {% else %}
-                {{govukTag({
-                  text: "Unavailable",
-                  classes: "govuk-tag--grey tab-content-value__not-provided"
-                })}}
-              {% endif %}
-            </span>
-          </span>
-        </div>
+          </div>
+        {% endif %}
         <p class='search-result__content'>
           {{ item.content | safe }}
         </p>
@@ -132,7 +140,7 @@
         {% if item.nceaContribution %}
           {{nceaContribution (assetPath, item.nceaContribution)}}
         {% endif %}
-        
+
         <div class='govuk-button-group search-result__button-group'>
           {# {{ goToResource({ organisationName: item.organisationName, resourceLocator: item.resourceLocator, isDetailsPage: false }) }} #}
           {{ govukButton({

--- a/src/views/partials/results/summary.njk
+++ b/src/views/partials/results/summary.njk
@@ -101,7 +101,7 @@
         {% endif %}
         {% if item.displayDataSetReferenceDate %}
           <div class='search-result__parameter'>
-            <span class='search-result__parameter-label search-result__published-label'>Dataset reference date</span>
+            <span class='search-result__parameter-label search-result__published-label'>{{ item.dataSetReferenceLabel }}</span>
             <span class='search-result__parameter-value search-result__published-value'>{{ item.dataSetReferenceDate }}</span>
           </div>
         {% endif %}


### PR DESCRIPTION
### What one thing this PR does?

In this PR, I have added the Dataset reference date in Search Result Section. 

### Task details

- [NCEA-191 - Update Date Search Filter to use new API params](https://dsp-support.atlassian.net/browse/NCEA-191)

### Other notes

### How do these changes look like?
![Screenshot from 2025-04-15 11-25-30](https://github.com/user-attachments/assets/d0f5e9ca-2e76-4891-b127-a36a7f909b0a)
![Screenshot from 2025-04-14 11-38-09](https://github.com/user-attachments/assets/1f29a3da-e088-4fde-978d-c87e86e89209)

### Dev-tested in

1. Local environment

- [Search Results](http://localhost:4000/natural-capital-ecosystem-assessment/search?date-before=&date-after=&licence=&keywords=Water&scope=all&q=disease&rpp=20&srt=most_relevant&jry=qs&pg=1)
- [More Info(http://localhost:4000/natural-capital-ecosystem-assessment/search/bbcb8fca-2c40-441b-96c9-78c36893a4f0?date-before=&date-after=&licence=&keywords=Water&scope=all&q=disease&rpp=20&srt=most_relevant&jry=qs&pg=1#quality)

2. Dev environment

- [Page name/link 1](url)
- ...
