### PR TITLE
NCEA-290 Update filter options for Service Types

### DIFF
--- a/__tests__/utils/getAccessTabData.spec.ts
+++ b/__tests__/utils/getAccessTabData.spec.ts
@@ -3,8 +3,10 @@ import {
   generateResourceWebsiteTable,
   createDownloadsTableRow,
   extractFileFormat,
+  validateServiceTypes,
 } from '../../src/utils/getAccessTabData';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
+import { DATA_DOWNLOADS_TYPES, DATA_SERVICES_TYPES } from '../../src/utils/constants';
 
 describe('getAccessTabData functions', () => {
   describe('getAccessTabData result', () => {
@@ -67,6 +69,15 @@ describe('getAccessTabData functions', () => {
           'http://data.defra.gov.uk/Agriculture/Notifiable_Disease_Datasets_Additional_Information.odt',
         ),
       ).toStrictEqual('ODT');
+    });
+  });
+
+  describe('validateServiceTypes', () => {
+    it('should validate validate the service types by converting into the lowercase', () => {
+      expect(validateServiceTypes(DATA_SERVICES_TYPES, 'HTTP web resource')).toStrictEqual(true);
+      expect(validateServiceTypes(DATA_DOWNLOADS_TYPES, 'HTTP FILE DOWNLOAD')).toStrictEqual(true);
+      expect(validateServiceTypes(DATA_DOWNLOADS_TYPES, 'ABC')).toStrictEqual(false);
+      expect(validateServiceTypes(DATA_DOWNLOADS_TYPES, '')).toStrictEqual(false);
     });
   });
 });

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -375,3 +375,7 @@ export interface NceaClassifier {
   naturalCapitalCategory: string[];
   naturalCapitalSubCategory: string[];
 }
+
+export interface ServiceOptions {
+  [key: string]: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -408,5 +408,15 @@ export const nceaClassifiersMockTableData = {
 export const DATASET_PUBLICATION_DATE_LABEL = 'Dataset publication date';
 export const DATASET_REVISION_DATE_LABEL = 'Dataset revision date';
 export const DATASET_CREATION_DATE_LABEL = 'Dataset creation date';
-export const DATA_SERVICES_TYPES = ['WFS', 'WMS', 'HTTP Application', 'ESRI REST API'];
-export const DATA_DOWNLOADS_TYPES = ['HTTP file download'];
+export const DATA_DOWNLOADS_TYPES = {
+  HTTP_FILE_DOWNLOAD: 'HTTP File Download',
+};
+export const DATA_SERVICES_TYPES = {
+  WFS: 'WFS',
+  WMS: 'WMS',
+  HTTP_APPLICATION: 'HTTP Application',
+  ESRI_REST_API: 'ESRI REST API',
+  HTTP_WEB_RESOURCE: 'HTTP Web Resource',
+  OCG_API_FEATURES: 'OGC API Features',
+  REST_API: 'REST API',
+};

--- a/src/utils/getAccessTabData.ts
+++ b/src/utils/getAccessTabData.ts
@@ -5,7 +5,14 @@ import { DATA_DOWNLOADS_TYPES, DATA_SERVICES_TYPES } from './constants';
 import { capitalizeWords } from './formatAggregationResponse';
 import { getOrganisationDetails } from './getOrganisationDetails';
 import { isEmpty } from './isEmpty';
-import { Contact, IAccess, IAccessItem, IIdentifiers, IResources } from '../interfaces/searchResponse.interface';
+import {
+  Contact,
+  IAccess,
+  IAccessItem,
+  IIdentifiers,
+  IResources,
+  ServiceOptions,
+} from '../interfaces/searchResponse.interface';
 
 const getCoupledResource = (data: string | string[]): string => {
   const getCoupleResourceLink = (url: string): string => {
@@ -87,10 +94,21 @@ const getIdentifiers = (identifier: IIdentifiers[]) => {
   return '';
 };
 
+export const validateServiceTypes = (options: ServiceOptions, value: string): boolean => {
+  const lowerCaseServiceTypes = Object.values(options).map((item) => item.toLowerCase());
+  const lowerCaseServiceTypesSet = new Set(lowerCaseServiceTypes);
+
+  return lowerCaseServiceTypesSet.has(value.toLowerCase());
+};
+
 export const generateResourceWebsiteTable = (resources: IResources[]) => {
   if (Array.isArray(resources) && resources.length > 0) {
-    const filterDataServicesSet = resources.filter(({ type }) => type !== null && DATA_SERVICES_TYPES.includes(type));
-    const filterDataDownloadSet = resources.filter(({ type }) => type !== null && DATA_DOWNLOADS_TYPES.includes(type));
+    const filterDataServicesSet = resources.filter(
+      ({ type }) => type !== null && validateServiceTypes(DATA_SERVICES_TYPES, type),
+    );
+    const filterDataDownloadSet = resources.filter(
+      ({ type }) => type !== null && validateServiceTypes(DATA_DOWNLOADS_TYPES, type),
+    );
     const dataServicesTable = generateDataServicesTable(filterDataServicesSet);
     const dataDownloadTable = generateDataDownloadsTable(filterDataDownloadSet);
 

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -340,7 +340,7 @@ export const searchFilters: ISearchFilters = [
     filters: [
       {
         name: 'HTTP File Download',
-        value: 'HTTP file download',
+        value: 'HTTP File Download',
         scope: DataScope.IGNORE,
       },
       {

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -340,7 +340,7 @@ export const searchFilters: ISearchFilters = [
     filters: [
       {
         name: 'HTTP File Download',
-        value: 'HTTP File Download',
+        value: 'HTTP file download',
         scope: DataScope.IGNORE,
       },
       {


### PR DESCRIPTION
### What one thing this PR does?
In this PR, I have updated the service type filter for HTTP file download.

A sample one-liner about this task.

### Task details

- [NCEA-290 - Update filter options for Service Types](https://dsp-support.atlassian.net/browse/NCEA-290)

### Other notes

- Additional details about the task
- Important points that other teams or reviewers should be aware of.

### How do these changes look like?
![Screenshot from 2025-04-17 08-11-15](https://github.com/user-attachments/assets/024d1874-d480-4487-8233-681e658f6fa8)


### Dev-tested in

1. Local environment

- [Search Result Page](http://localhost:4000/natural-capital-ecosystem-assessment/search?svt=HTTP+file+download&date-before=&date-after=&licence=&keywords=&scope=all&q=disease&rpp=20&srt=most_relevant&jry=qs&pg=1)
