### PR TITLE
NCEA-295 - Hook up UI category search to new endpoint

### DIFF
--- a/__tests__/config/environmentConfig.spec.ts
+++ b/__tests__/config/environmentConfig.spec.ts
@@ -48,7 +48,7 @@ describe('Environment environmentConfig', () => {
       const { environmentConfig } = require('../../src/config/environmentConfig');
       expect(environmentConfig).toBeDefined();
       expect(typeof environmentConfig).toBe('object');
-      expect(Object.keys(environmentConfig).length).toBe(14);
+      expect(Object.keys(environmentConfig).length).toBe(15);
     });
 
     it('should validate and export the configuration object', () => {
@@ -83,6 +83,7 @@ describe('Environment environmentConfig', () => {
         auth0JwtEnv: Joi.string().allow('').default(''),
         searchApiUrl: Joi.string(),
         vocabularyApiUrl: Joi.string(),
+        categoryResultCountApiUrl: Joi.string(),
       });
 
       const { environmentConfig } = require('../../src/config/environmentConfig');

--- a/__tests__/infrastructure/server.spec.ts
+++ b/__tests__/infrastructure/server.spec.ts
@@ -43,6 +43,7 @@ describe('Server initialization', () => {
         appInsightsConnectionString: 'test',
         searchApiUrl: 'https://example.com/api',
         vocabularyApiUrl: 'https://example.com/api',
+        categoryResultCountApiUrl: 'https://example.com/api'
       },
     }));
 

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -233,7 +233,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37397%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37391%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -842,7 +842,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
       
     
    data-to-disable="" data-next-question="">
-  Next
+  Next4444
 </button>
 
           </div>

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -236,7 +236,7 @@ exports[`Details route template Document details with data Check status code and
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42691%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41777%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -1661,7 +1661,6 @@ exports[`Details route template Document details with data Check status code and
   </script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery-debounce.js"></script>
-  <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
   <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/dataModal.js"></script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/ol.js"></script>
   <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>
@@ -1909,7 +1908,7 @@ exports[`Details route template Document details with partial data Check status 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37913%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37103%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -3038,7 +3037,6 @@ exports[`Details route template Document details with partial data Check status 
   </script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery.js"></script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/jquery-debounce.js"></script>
-  <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/filters.js"></script>
   <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/dataModal.js"></script>
   <script src="/natural-capital-ecosystem-assessment/assets/scripts/ol.js"></script>
   <script type="module" src="/natural-capital-ecosystem-assessment/assets/scripts/location.js"></script>

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -236,7 +236,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37623%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40637%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -236,7 +236,7 @@ exports[`Results block template Guided search journey Search results with empty 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36373%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44977%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -2473,7 +2473,7 @@ exports[`Results block template Guided search journey Search results with error 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40451%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46451%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -3518,7 +3518,7 @@ exports[`Results block template Quick search journey Search results with data sh
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35223%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46241%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -5982,7 +5982,7 @@ exports[`Results block template Quick search journey Search results with empty d
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33255%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38849%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -8219,7 +8219,7 @@ exports[`Results block template Quick search journey Search results with error s
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39931%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A37715%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/schema/environmentConfig.schema.spec.ts
+++ b/__tests__/schema/environmentConfig.schema.spec.ts
@@ -55,7 +55,7 @@ describe('Environment Configuration Schema', () => {
         auth0JwtEnv: 'test',
         searchApiUrl: 'https://example.com/api',
         vocabularyApiUrl: 'https://example.com/api',
-         categoryResultCountApiUrl: 'https://example.com/api'
+        categoryResultCountApiUrl: 'https://example.com/api',
       };
 
       const { error, value } = environmentSchema.validate(validConfig);

--- a/__tests__/schema/environmentConfig.schema.spec.ts
+++ b/__tests__/schema/environmentConfig.schema.spec.ts
@@ -55,6 +55,7 @@ describe('Environment Configuration Schema', () => {
         auth0JwtEnv: 'test',
         searchApiUrl: 'https://example.com/api',
         vocabularyApiUrl: 'https://example.com/api',
+         categoryResultCountApiUrl: 'https://example.com/api'
       };
 
       const { error, value } = environmentSchema.validate(validConfig);

--- a/__tests__/services/handlers/searchApi.spec.ts
+++ b/__tests__/services/handlers/searchApi.spec.ts
@@ -5,7 +5,6 @@ import { getFilterOptions, getSearchResults, getSearchResultsCount } from '../..
 import { formatSearchResponse } from '../../../src/utils/formatSearchResponse';
 import { IAggregationOptions } from '../../../src/interfaces/searchResponse.interface';
 import { QUICK_SEARCH_RESPONSE } from '../../../src/services/handlers/mocks/quick-search';
-import { CLASSIFIER_COUNT_LEVEL_2 } from '../../../src/services/handlers/mocks/classifier-themes-level-2';
 import { applyMockFilters, DataScope } from '../../../src/utils/searchFilters';
 import { requestMockData } from '../../data/requestData';
 import { processDSPFilterOptions } from '../../../src/utils//processFilterRSortOptions';
@@ -209,23 +208,7 @@ describe('Search API', () => {
         ok: true,
         json: () => Promise.resolve({ totalDocumentCount: 10 }),
       });
-      const searchFieldsObject: ISearchPayload = {
-        fields: {
-          keyword: {
-            q: 'example',
-          },
-        },
-        sort: '',
-        filters: {},
-        rowsPerPage: 20,
-        page: 1,
-      };
-      const processedDspFilterOptions = processDSPFilterOptions({ level: '3', 'parent[]': 'lv2-001,lv2-002' });
-      const result = await getSearchResultsCount(
-        searchFieldsObject,
-        requestMockData.auth.credentials,
-        processedDspFilterOptions,
-      );
+      const result = await getSearchResultsCount('lv2-001,lv2-002', requestMockData.auth.credentials);
       expect(result).toEqual({ totalResults: 10 });
     });
 
@@ -234,18 +217,7 @@ describe('Search API', () => {
         ok: true,
         json: () => Promise.resolve({ totalDocumentCount: 0 }),
       });
-      const processedDspFilterOptions = processDSPFilterOptions({ level: '3', 'parent[]': 'lv2-001,lv2-002' });
-      const result = await getSearchResultsCount(
-        {
-          fields: {},
-          sort: '',
-          rowsPerPage: 20,
-          filters: {},
-          page: 1,
-        },
-        requestMockData.auth.credentials,
-        processedDspFilterOptions,
-      );
+      const result = await getSearchResultsCount('lv2-001,lv2-002', requestMockData.auth.credentials);
       expect(result).toEqual({ totalResults: 0 });
     });
   });

--- a/__tests__/utils/queryStringHelper.spec.ts
+++ b/__tests__/utils/queryStringHelper.spec.ts
@@ -10,6 +10,7 @@ import {
   generateQueryBuilderFields,
   generateQueryBuilderPayload,
   deleteQueryParams,
+  removeDuplicatesValues,
 } from '../../src/utils/queryStringHelper';
 
 describe('queryStringHelper functions', () => {
@@ -111,9 +112,7 @@ describe('queryStringHelper functions', () => {
 
   describe('getDateParams', () => {
     test('should return date parameters from URLSearchParams', () => {
-      const searchParams = new URLSearchParams(
-        'fdd=01&fdm=01&fdy=2023&tdd=31&tdm=12&tdy=2023',
-      );
+      const searchParams = new URLSearchParams('fdd=01&fdm=01&fdy=2023&tdd=31&tdm=12&tdy=2023');
       const result = getDateParams(searchParams);
       expect(result).toEqual({
         fdd: '01',
@@ -389,6 +388,14 @@ describe('queryStringHelper functions', () => {
           resourceTypeFilter: ['article'],
         },
       });
+    });
+  });
+  describe('removeDuplicatesValues', () => {
+    it('should return empty string if the input value is passed as empty or null', () => {
+      expect(removeDuplicatesValues('')).toStrictEqual('');
+    });
+    it('should return expected output and removed the duplicates', () => {
+      expect(removeDuplicatesValues('A,A,A,A,A,A,A,B,B,C,C,D,D,D')).toStrictEqual('A,B,C,D');
     });
   });
 });

--- a/src/config/environmentConfig.ts
+++ b/src/config/environmentConfig.ts
@@ -27,6 +27,7 @@ const config: EnvironmentConfig = {
   auth0JwtEnv: process.env.AUTH0_JWT_ENV,
   searchApiUrl: process.env.SEARCH_API,
   vocabularyApiUrl: process.env.VOCABULARY_API,
+  categoryResultCountApiUrl: process.env.CATEGORY_RESULT_COUNT_API,
 };
 
 const { error, value } = environmentSchema.validate(config);

--- a/src/controllers/web/ClassifierSearchController.ts
+++ b/src/controllers/web/ClassifierSearchController.ts
@@ -6,8 +6,7 @@ import { Credentials } from '../../interfaces/auth';
 import { getClassifierThemes } from '../../services/handlers/classifierApi';
 import { getSearchResultsCount } from '../../services/handlers/searchApi';
 import { BASE_PATH, formIds, pageTitles, queryParamKeys, webRoutePaths } from '../../utils/constants';
-import { processDSPFilterOptions } from '../../utils/processFilterRSortOptions';
-import { generateCountPayload, readQueryParams, upsertQueryParams } from '../../utils/queryStringHelper';
+import { readQueryParams, removeDuplicatesValues, upsertQueryParams } from '../../utils/queryStringHelper';
 
 const ClassifierSearchController = {
   renderClassifierSearchHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
@@ -15,33 +14,31 @@ const ClassifierSearchController = {
     const formId: string = formIds.classifierSearch;
     const level: number = Number(readQueryParams(request.query, 'level'));
     const parent: string = readQueryParams(request.query, 'parent[]') || '';
+    const parentIds = removeDuplicatesValues(parent);
     const nextLevel: string = (level + 1).toString();
     const payloadQuery = {
       ...request.query,
       level: (level - 1).toString(),
     };
     const classifierPageTitle = pageTitles.Classifier[level - 1];
-    const countPayload = generateCountPayload(payloadQuery);
-    const processedDspFilterOptions = processDSPFilterOptions(request.query);
-    const totalCount = (
-      await getSearchResultsCount(countPayload, request.auth.credentials as Credentials, processedDspFilterOptions)
-    ).totalResults.toString();
-
+    const [resultCountData, classifierItems] = await Promise.all([
+      getSearchResultsCount(parentIds, request.auth.credentials as Credentials),
+      getClassifierThemes(level.toString(), parentIds),
+    ]);
     const queryParamsObject: Record<string, string> = {
       ...request.query,
       level: (level - 1).toString(),
       [queryParamKeys.journey]: 'gs',
-      [queryParamKeys.count]: totalCount,
+      [queryParamKeys.count]: resultCountData.totalResults.toString(),
     };
 
     const queryString: string = level - 1 > 0 ? upsertQueryParams(payloadQuery, queryParamsObject, true) : '';
     const resultsPath: string = `${BASE_PATH}${results}?${readQueryParams(queryParamsObject, '', true)}`;
-    const classifierItems = await getClassifierThemes(level.toString(), parent);
 
     if (classifierItems.length <= 0) {
       return response.redirect(resultsPath);
     }
-    const hasSearchResultOrlevelFirst = Number(totalCount) > 0 || level == 1;
+    const hasSearchResultOrlevelFirst = Number(resultCountData.totalResults) > 0 || level == 1;
 
     if (hasSearchResultOrlevelFirst) {
       return response.view('screens/guided_search/classifier_selection.njk', {
@@ -52,7 +49,7 @@ const ClassifierSearchController = {
         formId,
         journey: 'gs',
         classifierItems,
-        count: level >= 1 ? totalCount : null,
+        count: level >= 1 ? resultCountData.totalResults.toString() : null,
         resultsPath,
         backLinkPath: '#',
         backLinkClasses: 'back-link-classifier',

--- a/src/controllers/web/DateSearchController.ts
+++ b/src/controllers/web/DateSearchController.ts
@@ -16,18 +16,16 @@ import {
   queryParamKeys,
   webRoutePaths,
 } from '../../utils/constants';
-import { processDSPFilterOptions } from '../../utils/processFilterRSortOptions';
-import { generateCountPayload, readQueryParams, upsertQueryParams } from '../../utils/queryStringHelper';
+import { readQueryParams, removeDuplicatesValues, upsertQueryParams } from '../../utils/queryStringHelper';
 import { transformErrors } from '../../utils/transformErrors';
 
 const DateSearchController = {
   renderGuidedSearchHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
     const { guidedDateSearch, geographySearch, results } = webRoutePaths;
     const formId: string = formIds.dataQuestionnaireFID;
-    const countPayload = generateCountPayload(request.query);
-    const processedDspFilterOptions = processDSPFilterOptions(request.query);
+    const parent: string = removeDuplicatesValues(readQueryParams(request.query, 'parent[]') ?? '');
     const count = (
-      await getSearchResultsCount(countPayload, request.auth.credentials as Credentials, processedDspFilterOptions)
+      await getSearchResultsCount(parent, request.auth.credentials as Credentials)
     ).totalResults.toString();
 
     const queryParamsObject: Record<string, string> = {

--- a/src/interfaces/environmentConfig.interface.ts
+++ b/src/interfaces/environmentConfig.interface.ts
@@ -13,4 +13,5 @@ export interface EnvironmentConfig {
   auth0JwtEnv?: string;
   searchApiUrl: string | undefined;
   vocabularyApiUrl: string | undefined;
+  categoryResultCountApiUrl: string | undefined;
 }

--- a/src/schema/environmentConfig.schema.ts
+++ b/src/schema/environmentConfig.schema.ts
@@ -55,4 +55,7 @@ export const environmentSchema: Joi.ObjectSchema = Joi.object({
   vocabularyApiUrl: Joi.string().uri().messages({
     'string.uri': 'Vocabulary API must be a valid URL',
   }),
+  categoryResultCountApiUrl: Joi.string().uri().messages({
+    'string.uri': 'Category Result Count API must be a valid URL',
+  }),
 });

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -1,6 +1,7 @@
 import { RequestQuery } from '@hapi/hapi';
 
 import { FILTER_VALUES, queryParamKeys, resourceTypeFilterField, studyPeriodFilterField } from './constants';
+import { isEmpty } from './isEmpty';
 import { ISearchFields, ISearchPayload } from '../interfaces/queryBuilder.interface';
 
 const getMetaQueryParams = (requestQuery: RequestQuery): URLSearchParams => {
@@ -99,7 +100,7 @@ const readListQueryParams = (requestQuery: RequestQuery, key: string): string[] 
   }
 
   /*When user selected  organisation or dataFormate of only single item, so value in requestQuery
-  as string formate, if the item  string as contains the commas, it treated as the multiple item with 
+  as string formate, if the item  string as contains the commas, it treated as the multiple item with
   below split, So in this case we does not required the split, just return it as the array of string. */
   if (key === FILTER_VALUES.organisation || key === FILTER_VALUES.dataFormat) {
     return [keyItems];
@@ -215,6 +216,13 @@ const appendPublication = (resourceTypes: string): string => {
   return resourceTypes;
 };
 
+const removeDuplicatesValues = (data: string) => {
+  if (!isEmpty(data)) {
+    return [...new Set(data.split(','))].join(',');
+  }
+  return '';
+};
+
 export {
   getQueryStringParams,
   upsertQueryParams,
@@ -230,4 +238,5 @@ export {
   deleteQueryParams,
   appendPublication,
   getMetaQueryParams,
+  removeDuplicatesValues,
 };


### PR DESCRIPTION
### What one thing this PR does?

Replaced the search results count API with the category result count API. The previous API fetched all search result data along with the count, which led to slower performance. The result count API fetches only  the count, significantly improving load time.

A sample one-liner about this task.

### Task details

- [NCEA-295 - Hook up UI category search to new endpoint](https://dsp-support.atlassian.net/browse/NCEA-294)

### Other notes

Please add the variable into the .env file
`CATEGORY_RESULT_COUNT_API=https://environment-test.data.gov.uk/api/categoryrecordcount`

### Dev-tested in

1. Local environment

- Category Pages/link 1](http://localhost:4000/natural-capital-ecosystem-assessment/classifier-search?jry=gs&level=2&parent%5B%5D=lvl1_001&parent%5B%5D=lvl1_002)