### PR TITLE
NCEA-296 - Clear Filters button removes query information after a classifier search

### DIFF
--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -10,7 +10,7 @@ const formGroupErrorClass = 'govuk-form-group--error';
 const displayNoneClass = 'display-none';
 
 const validYearRegex = /^$|^[0-9]{4}$/; // matches empty string OR 4 digit number
-const BASE_PATH = '/natural-capital-ecosystem-assessment';
+
 /**
  * Attatch event listeners to the filters accordions so
  * they can be interacted with (opened and closed).

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -122,18 +122,6 @@ const filterFormToFormData = (form) => {
   return data;
 };
 
-const buildResetFilterURl = (formData) => {
-  const params = new URLSearchParams(window.location.search);
-
-  for (const key of formData.keys()) {
-    if (params.has(key) && params.get(key).trim() !== '') {
-      params.delete(key);
-    }
-  }
-
-  return params;
-};
-
 /**
  * Attatch event listener to the form reset
  * so it resets the filters correctly, instead of relying on default
@@ -143,13 +131,12 @@ const buildResetFilterURl = (formData) => {
  */
 const addFilterFormResetListener = (instance) => {
   const formSubmit = document.getElementById(`filters-${instance}`);
-  const formData = filterFormToFormData(formSubmit);
+  const resetButton = document.getElementById(`filters-reset-${instance}`);
 
   formSubmit.addEventListener('reset', (e) => {
     e.preventDefault();
 
-    const params = buildResetFilterURl(formData);
-    window.location.href = `${BASE_PATH}/search?${params.toString()}`;
+    window.location.href = resetButton.getAttribute('data-reset-url');
   });
 };
 

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -10,7 +10,7 @@ const formGroupErrorClass = 'govuk-form-group--error';
 const displayNoneClass = 'display-none';
 
 const validYearRegex = /^$|^[0-9]{4}$/; // matches empty string OR 4 digit number
-
+const BASE_PATH = '/natural-capital-ecosystem-assessment';
 /**
  * Attatch event listeners to the filters accordions so
  * they can be interacted with (opened and closed).
@@ -122,6 +122,18 @@ const filterFormToFormData = (form) => {
   return data;
 };
 
+const buildResetFilterURl = (formData) => {
+  const params = new URLSearchParams(window.location.search);
+
+  for (const key of formData.keys()) {
+    if (params.has(key) && params.get(key).trim() !== '') {
+      params.delete(key);
+    }
+  }
+
+  return params;
+};
+
 /**
  * Attatch event listener to the form reset
  * so it resets the filters correctly, instead of relying on default
@@ -131,12 +143,13 @@ const filterFormToFormData = (form) => {
  */
 const addFilterFormResetListener = (instance) => {
   const formSubmit = document.getElementById(`filters-${instance}`);
-  const resetButton = document.getElementById(`filters-reset-${instance}`);
+  const formData = filterFormToFormData(formSubmit);
 
   formSubmit.addEventListener('reset', (e) => {
     e.preventDefault();
 
-    window.location.href = resetButton.getAttribute('data-reset-url');
+    const params = buildResetFilterURl(formData);
+    window.location.href = `${BASE_PATH}/search?${params.toString()}`;
   });
 };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -420,3 +420,12 @@ export const DATA_SERVICES_TYPES = {
   OCG_API_FEATURES: 'OGC API Features',
   REST_API: 'REST API',
 };
+
+export const FILTER_NAMES = {
+  ...FILTER_VALUES,
+  retiredAndArchived: 'retired-archived',
+  keywords: 'keywords',
+  licence: 'licence',
+  updatedBefore: 'date-before',
+  updatedAfter: 'date-after',
+};

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -10,7 +10,7 @@ import {
 import { isEmpty } from './isEmpty';
 import { ISearchFields, ISearchPayload } from '../interfaces/queryBuilder.interface';
 
-const getMetaQueryParams = (requestQuery: RequestQuery): URLSearchParams => {
+const getClearFilterUrl = (requestQuery: RequestQuery): URLSearchParams => {
   const searchParams = getQueryStringParams(requestQuery);
 
   for (const key of Object.values(FILTER_NAMES)) {
@@ -242,6 +242,6 @@ export {
   getClassifierParams,
   deleteQueryParams,
   appendPublication,
-  getMetaQueryParams,
+  getClearFilterUrl,
   removeDuplicatesValues,
 };

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -1,20 +1,25 @@
 import { RequestQuery } from '@hapi/hapi';
 
-import { FILTER_VALUES, queryParamKeys, resourceTypeFilterField, studyPeriodFilterField } from './constants';
+import {
+  FILTER_NAMES,
+  FILTER_VALUES,
+  queryParamKeys,
+  resourceTypeFilterField,
+  studyPeriodFilterField,
+} from './constants';
 import { isEmpty } from './isEmpty';
 import { ISearchFields, ISearchPayload } from '../interfaces/queryBuilder.interface';
 
 const getMetaQueryParams = (requestQuery: RequestQuery): URLSearchParams => {
   const searchParams = getQueryStringParams(requestQuery);
-  const filterParams = new URLSearchParams();
 
-  filterParams.set(queryParamKeys.quickSearch, searchParams.get(queryParamKeys.quickSearch) ?? '');
-  filterParams.set(queryParamKeys.rowsPerPage, searchParams.get(queryParamKeys.rowsPerPage) ?? '10');
-  filterParams.set(queryParamKeys.sort, searchParams.get(queryParamKeys.sort) ?? 'most_relevant');
-  filterParams.set(queryParamKeys.journey, searchParams.get(queryParamKeys.journey) ?? '');
-  filterParams.set(queryParamKeys.page, searchParams.get(queryParamKeys.page) ?? '1');
+  for (const key of Object.values(FILTER_NAMES)) {
+    if (searchParams.has(key) && searchParams.get(key)?.trim() !== '') {
+      searchParams.delete(key);
+    }
+  }
 
-  return filterParams;
+  return searchParams;
 };
 
 const setDefaultQueryParams = (searchParams: URLSearchParams): URLSearchParams => {

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -3,7 +3,7 @@ import { RequestQuery } from '@hapi/hapi';
 
 import { BASE_PATH, FILTER_VALUES, webRoutePaths } from './constants';
 import { convertToDate } from './dates';
-import { getMetaQueryParams, readQueryParams } from './queryStringHelper';
+import { getClearFilterUrl, readQueryParams } from './queryStringHelper';
 
 export const filterNames = {
   scope: 'scope',
@@ -59,7 +59,7 @@ export const buildFilterResetUrl = (requestQuery: RequestQuery): string => {
   // this will only return the meta params important to the query
   // this is required otherwise the reset url would reflect all the filters enabled, which
   // would mean nothing gets reset.
-  const params = getMetaQueryParams(requestQuery);
+  const params = getClearFilterUrl(requestQuery);
 
   params.set(filterNames.scope, nceaOnly ? DataScope.NCEA : DataScope.ALL);
 


### PR DESCRIPTION
### What one thing this PR does?

Previously, clearing filters in the search results page would reset the entire URL, removing all query parameters and reloading the page. This behavior disrupted use cases like category-based searches, where level and parents parameters need to persist. This update refines the filter-clearing logic to only remove the applied filter values while retaining existing query parameters such as level and parents. This ensures a smoother user experience and maintains the context of the current search.

### Task details

- [NCEA-296 -Clear Filters`button removes query information after a classifier search](https://dsp-support.atlassian.net/browse/NCEA-296)

### Dev-tested in

1. Local environment

- [Search Result Page](http://localhost:4000/natural-capital-ecosystem-assessment/search?date-before=&date-after=&licence=&keywords=&scope=all&jry=gs&srt=most_relevant&rpp=20&pg=1&level=3&parent%5B%5D=lvl3_016)