### PR TITLE
NCEA-297 - Keywords list does not show up in map view after changing data scope

### DIFF
--- a/public/scripts/keywordsFilter.js
+++ b/public/scripts/keywordsFilter.js
@@ -122,11 +122,7 @@ const checkDuplicateKeywords = (filtersInstanceId, keyword) => {
   return false;
 };
 
-$(document).ready(function () {
-  createBadgesFromExistingKeywords('#keyword-badge-container-search_results');
-  const filterType = 'search_results';
-  const keywordInput = $(`#filters-keywords-${filtersInstance}`);
-
+const loadKeyboardListData = () => {
   const getTagsApiUrl = Boolean(keyboardFiltersBaseUrlValue)
     ? `${keyboardFiltersBaseUrlValue}/backend/catalog/api/catalog/tags`
     : '/backend/catalog/api/catalog/tags';
@@ -145,15 +141,9 @@ $(document).ready(function () {
       $('.filter-options__keyboard-filter-list').append(liElement);
     },
   });
-  $(document).click(function (event) {
-    if (
-      !$(event.target).closest('#filters-keywords-search_results').length &&
-      !$(event.target).closest('filter-options__keyboard-filter-content-' + filterType).length
-    ) {
-      $('.filter-options__keyboard-filter-content-' + filterType).hide();
-    }
-  });
-  keywordsDropdownListAction(keywordInput, filterType);
+};
+
+const keywordSelectEventHandlder = (keywordInput, filterType) => {
   $('#keyboard-filter-list').on('click', 'li', function () {
     const selectedValue = $(this).text();
     keywordInput.val('');
@@ -183,6 +173,30 @@ $(document).ready(function () {
       window.history.pushState({}, '', url);
     }
   });
+};
+
+$(document).ready(function () {
+  createBadgesFromExistingKeywords('#keyword-badge-container-search_results');
+  loadKeyboardListData();
+  const filterType = 'search_results';
+  const keywordInput = $(`#filters-keywords-${filtersInstance}`);
+  $(document).click(function (event) {
+    if (
+      !$(event.target).closest('#filters-keywords-search_results').length &&
+      !$(event.target).closest('filter-options__keyboard-filter-content-' + filterType).length
+    ) {
+      $('.filter-options__keyboard-filter-content-' + filterType).hide();
+    }
+  });
+  keywordsDropdownListAction(keywordInput, filterType);
+  keywordSelectEventHandlder(keywordInput, filterType);
 });
 
-export { createBadge, keywordsDropdownListAction, checkDuplicateKeywords, createBadgesFromExistingKeywords };
+export {
+  createBadge,
+  keywordsDropdownListAction,
+  checkDuplicateKeywords,
+  createBadgesFromExistingKeywords,
+  loadKeyboardListData,
+  keywordSelectEventHandlder,
+};

--- a/public/scripts/location.js
+++ b/public/scripts/location.js
@@ -9,6 +9,12 @@ import {
   addMapFilterFormResetListener,
   addAllCheckboxListeners,
 } from './filters.js';
+import {
+  loadKeyboardListData,
+  keywordsDropdownListAction,
+  createBadge,
+  checkDuplicateKeywords,
+} from './keywordsFilter.js';
 
 const mapResultsInstance = 'map_results';
 const index3 = 3;
@@ -864,6 +870,38 @@ const getMapResults = async (path, fitToMapExtentFlag) => {
       attachBoundingBoxToggleListener();
       // don't need to handle the `else` cases anymore as it start disabled by default
     }
+
+    // intialize the keywords functionality whenerver the DOM refreshed
+    const keywordInput = $(`#filters-keywords-map_results`);
+    const filterType = 'map_results';
+    loadKeyboardListData();
+    keywordsDropdownListAction(keywordInput, filterType);
+
+    $('#keyboard-filter-list').on('click', 'li', function () {
+      const selectedValue = $(this).text();
+      keywordInput.val('');
+      keywordInput.focus();
+      if (!$(this).hasClass('keyword-filter-no-record-found')) {
+        keywordInput.val($(this).text());
+        $('.filter-options__keyboard-filter-content-' + filterType).hide();
+      }
+
+      if (!checkDuplicateKeywords('#keyword-badge-container-map_results', selectedValue)) {
+        createBadge(selectedValue, '#keyword-badge-container-map_results');
+        keywordInput.val('');
+        keywordInput.focus();
+        $(`.keyword-input-${filterType}-error-message`).hide();
+        $(`#filters-keywords-${filterType}`).removeClass('govuk-input--error');
+      }
+    });
+    $(document).click(function (event) {
+      if (
+        !$(event.target).closest('#filters-keywords-map_results').length &&
+        !$(event.target).closest('.filter-options__keyboard-filter-content-' + filterType).length
+      ) {
+        $('.filter-options__keyboard-filter-content-' + filterType).hide();
+      }
+    });
   }
 };
 


### PR DESCRIPTION
### What one thing this PR does?

Previously, switching the scope from `scope=all` to `scope=ncea` triggered a DOM refresh to update map results, but the client-side code handling keywords functionality was lost during this refresh. This commit reintroduces the keywords functionality logic so that it persists and works correctly after the scope change.

### Task details

- [NCEA-297 - Keywords list does not show up in map view after changing data scope](https://dsp-support.atlassian.net/browse/NCEA-297)
