### PR TITLE
NCEA 301 Monetary and non-monetary categories and their parent theme to be shown on subcategory page

### DIFF
--- a/public/scripts/categorySearch.js
+++ b/public/scripts/categorySearch.js
@@ -27,4 +27,33 @@ $(document).ready(function () {
       }
     });
   }
+
+  $('#classifier-search').on('submit', function (event) {
+    let skipFormValidation = false;
+    const selectedCheckboxes = $('input[name="parent[]"]:checked');
+    const checkboxGroups = $('.govuk-checkboxes');
+    const isAnyCheckboxNotSelected = selectedCheckboxes.length === 0;
+    const formData = new FormData(this);
+    const parentValues = formData.getAll('parent[]');
+
+    if (
+      (parentValues.includes('lvl2_009') && parentValues.includes('lvl2_010')) ||
+      parentValues.includes('lvl2_009') ||
+      parentValues.includes('lvl2_010')
+    ) {
+      skipFormValidation = true;
+    }
+
+    if (isAnyCheckboxNotSelected && !skipFormValidation) {
+      event.preventDefault();
+      $('#errorBlock').css('display', '');
+      checkboxGroups.each(function () {
+        handleError(this, 'apply');
+      });
+    } else {
+      checkboxGroups.each(function () {
+        handleError(this, 'remove');
+      });
+    }
+  });
 });

--- a/public/scripts/categorySearch.js
+++ b/public/scripts/categorySearch.js
@@ -1,0 +1,30 @@
+$(document).ready(function () {
+  const params = new URLSearchParams(window.location.search);
+  const level = Number(params.get('level'));
+  const parent = params.getAll('parent[]');
+
+  if (level === 3) {
+    const form = $('#classifier-search');
+    const messages = {
+      lvl2_009: 'Monetary',
+      lvl2_010: 'Non-monetary',
+    };
+
+    Object.entries(messages).forEach(([key, label]) => {
+      if (parent.includes(key)) {
+        $(`legend`)
+          .filter(function () {
+            return $(this).text().trim() === label;
+          })
+          .after(
+            '<div class="govuk-body">This category has no subcategories, so all its records will be selected.</div>',
+          );
+        $('<input>', {
+          type: 'hidden',
+          name: 'parent[]',
+          value: key,
+        }).appendTo(form);
+      }
+    });
+  }
+});

--- a/src/services/handlers/classifierApi.ts
+++ b/src/services/handlers/classifierApi.ts
@@ -1,5 +1,6 @@
 import { environmentConfig } from '../../config/environmentConfig';
 import { Classifiers, Classify } from '../../interfaces/classifierSearch.interface';
+import { monetaryCategory, naturalCapitalEvaluation, nonMonetaryCategory } from '../../utils/constants';
 
 const transformClassifierDetails = (classifiers: Classify[]): Classify[] => {
   return classifiers?.map((classifier) => ({
@@ -41,6 +42,7 @@ const invokeClassifierApi = async (level: string, parents: string = '') => {
 export const getClassifierThemes = async (level: string, parents: string = ''): Promise<Classifiers[]> => {
   try {
     const response = await invokeClassifierApi(level, parents);
+    const parentIdsArr = parents.split(',');
     const classifierResponse: Classifiers[] = [];
     response.forEach((classifier: Classifiers) => {
       if (classifier.level === 3) {
@@ -62,7 +64,19 @@ export const getClassifierThemes = async (level: string, parents: string = ''): 
         });
       }
     });
-
+    if (Number(level) === 3 && parentIdsArr.includes('lvl2_009') && parentIdsArr.includes('lvl2_010')) {
+      classifierResponse.push(naturalCapitalEvaluation);
+      classifierResponse.push(monetaryCategory);
+      classifierResponse.push(nonMonetaryCategory);
+    }
+    if (Number(level) === 3 && parentIdsArr.includes('lvl2_009') && !parentIdsArr.includes('lvl2_010')) {
+      classifierResponse.push(naturalCapitalEvaluation);
+      classifierResponse.push(monetaryCategory);
+    }
+    if (Number(level) === 3 && !parentIdsArr.includes('lvl2_009') && parentIdsArr.includes('lvl2_010')) {
+      classifierResponse.push(naturalCapitalEvaluation);
+      classifierResponse.push(nonMonetaryCategory);
+    }
     return classifierResponse;
   } catch (error: unknown) {
     return [];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -429,3 +429,33 @@ export const FILTER_NAMES = {
   updatedBefore: 'date-before',
   updatedAfter: 'date-after',
 };
+
+export const monetaryCategory = {
+  code: 'lvl2_009',
+  name: 'Monetary',
+  classifiers: [],
+  sectionTitle: 'Monetary',
+  sectionIntroduction: '',
+  text: '',
+  value: 'Monetary',
+  selectAll: 'lvl2_009',
+};
+
+export const nonMonetaryCategory = {
+  code: 'lvl2_010',
+  name: 'Non-monetary',
+  classifiers: [],
+  sectionTitle: 'Non-monetary',
+  sectionIntroduction: '',
+  text: '',
+  value: 'Non-monetary',
+  selectAll: 'lvl2_010',
+};
+
+export const naturalCapitalEvaluation = {
+  sectionTitle: 'Natural capital valuation',
+  sectionIntroduction:
+    'For the purposes of this search tool, natural capital valuation is defined as the method used to determine the value of an ecosystem service. This can be in non-monetary terms (e.g. heritage values or existence values) or in monetary terms (e.g. market price or willingness to pay). Select all that apply.',
+  classifiers: [],
+  selectAll: '',
+};

--- a/src/views/screens/guided_search/classifier_selection.njk
+++ b/src/views/screens/guided_search/classifier_selection.njk
@@ -119,6 +119,8 @@
 </div>{% endblock %}{% block bodyEnd %}
 {{ super() }}
 <script type="module" src="{{ assetPath }}/scripts/dataModal.js"></script>
+<script src="{{ assetPath }}/scripts/jquery.js"></script>
+<script type="module" src="{{ assetPath }}/scripts/categorySearch.js"></script>
 <script>
   function handleError(group, action) {
     const formGroup = group.closest('.govuk-form-group');

--- a/src/views/screens/guided_search/classifier_selection.njk
+++ b/src/views/screens/guided_search/classifier_selection.njk
@@ -34,7 +34,7 @@
     {% include "partials/results_count/template.njk" %}
     <div class='classifier-error-summary' id='errorBlock' style="display:none;">
       {{ govukErrorSummary({
-         titleText: "There is a problem11111",
+         titleText: "There is a problem",
          errorList: [
         {
            text: "You must select a theme to continue"

--- a/src/views/screens/guided_search/classifier_selection.njk
+++ b/src/views/screens/guided_search/classifier_selection.njk
@@ -34,7 +34,7 @@
     {% include "partials/results_count/template.njk" %}
     <div class='classifier-error-summary' id='errorBlock' style="display:none;">
       {{ govukErrorSummary({
-         titleText: "There is a problem",
+         titleText: "There is a problem11111",
          errorList: [
         {
            text: "You must select a theme to continue"
@@ -140,19 +140,4 @@
       }
     }
   }
-  document.getElementById('classifier-search').addEventListener('submit', function (event) {
-    const selectedCheckboxes = Array.from(document.querySelectorAll('input[name="parent[]"]:checked'));
-    const checkboxGroups = document.querySelectorAll('.govuk-checkboxes');
-    const isAnyCheckboxNotSelected = selectedCheckboxes.length === 0;
-    if (isAnyCheckboxNotSelected) {
-      event.preventDefault();
-      document
-        .getElementById("errorBlock")
-        .style
-        .display = '';
-      checkboxGroups.forEach(group => handleError(group, 'apply'));
-    } else {
-      checkboxGroups.forEach(group => handleError(group, 'remove'));
-    }
-  });
 </script>{% endblock %}


### PR DESCRIPTION
### What one thing this PR does?

Handled UI and submission behavior for "Monetary" and "Non-monetary" categories when no subcategories are returned from the API. It displays the message: "This category has no subcategories, so all its records will be selected." for Monetary and Non-monetary under the subcategory section .The IDs (lvl2_009 for Monetary and lvl2_010 for Non-monetary) are included as hidden inputs in the form, so they are passed in the search results API call.

### Task details

- [NCEA 301 - Monetary and non-monetary categories and their parent theme to be shown on subcategory page](https://dsp-support.atlassian.net/browse/NCEA-301)

### How do these changes look like?
If user selects non-monetary categories
![Screenshot from 2025-05-06 18-48-14](https://github.com/user-attachments/assets/2ecadec5-ac6d-426c-89ec-e5e0d0d48730)

If user selects Monetary category
![Screenshot from 2025-05-06 18-47-48](https://github.com/user-attachments/assets/4cb42696-62df-4787-96cc-c18b0a245acd)

If user selects Monetary and non-monetary categories
![Screenshot from 2025-05-06 18-50-22](https://github.com/user-attachments/assets/ca2f5b50-7d7f-451a-be7c-6f2684c4f4ec)

### Dev-tested in

1. Local environment

- [Category Search](http://localhost:3000/natural-capital-ecosystem-assessment/classifier-search?jry=gs&level=3&parent%5B%5D=lvl2_007&parent%5B%5D=lvl2_009&parent%5B%5D=lvl2_010)