### PR TITLE
NCEA-303 When exiting map view, search criteria not held if multiple parents from category search

### DIFF
--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -89,11 +89,20 @@ const appendMetaSearchParams = (filterParams) => {
   const params = new URLSearchParams(window.location.search);
 
   for (const [key, value] of params.entries()) {
-    if (!filterParams.has(key)) {
+    if (!filterParams.has(key) && key !== 'parent[]') {
       filterParams.set(key, value);
     }
     if (!!params.get('keywords')) {
       filterParams.set('keywords', params.get('keywords')); // set the keywords
+    }
+    if (key === 'parent[]') {
+      const existingValues = new Set(filterParams.getAll('parent[]'));
+      const values = params.getAll(key);
+      for (const value of values) {
+        if (!existingValues.has(value)) {
+          filterParams.append(key, value);
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
### What one thing this PR does?

Previously, when exiting the map in search results, only one parent ID was retained in the URL, leading to inconsistent results. This fix ensures that all parent IDs are correctly retained, providing accurate and consistent search results.

### Task details

- [NCEA-303 - When exiting map view, search criteria not held if multiple parents from category search](https://dsp-support.atlassian.net/browse/NCEA-303)

### Dev-tested in

1. Local environment

- [Search Result](url)