### PR TITLE
NCEA 309 Remove icons from standard header links

### DIFF
--- a/src/views/macros/header.njk
+++ b/src/views/macros/header.njk
@@ -62,7 +62,6 @@
           >
           {% for navLink in headerNavigationLinks %}
             <a class="govuk-link" href={{navLink.href}}>
-            {{icon(navLink.icon, { })}}
             <span>{{navLink.text}}</span>
             </a>
           {% endfor %}
@@ -72,7 +71,6 @@
         <nav class="navLinks secondary__navLinks service-links">
          {% for navLink in headerNavigationLinks %}
           <a class="govuk-link" href={{navLink.href}}>
-           {{icon(navLink.icon, { })}}
            <span>{{navLink.text}}</span>
           </a>
          {% endfor %}


### PR DESCRIPTION
### What one thing this PR does?

Removed the icons from the header links home ,about and news feed

A sample one-liner about this task.

### Task details

- [NCEA 309 - Remove icons from standard header links](https://dsp-support.atlassian.net/browse/NCEA-309)


### How do these changes look like?
![Screenshot from 2025-05-16 12-38-32](https://github.com/user-attachments/assets/f75d8bbd-d824-42c5-8fdc-d17cff4ba39b)


### Dev-tested in

1. Local environment

- [Home Page](http://localhost:4000/natural-capital-ecosystem-assessment)