### PR TITLE
NCEA-308 - Natural England blog not updating

### DIFF
--- a/src/controllers/web/AboutController.ts
+++ b/src/controllers/web/AboutController.ts
@@ -8,7 +8,7 @@ import { getFeedsData } from '../../utils/getFeedsData';
 const AboutController = {
   renderAboutHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
     try {
-      const feedsData = atomFeeds[0] ? await getFeedsData(atomFeeds[0]) : null;
+      const feedsData = atomFeeds[1] ? await getFeedsData(atomFeeds[1]) : null;
 
       return response.view('screens/about/template', {
         displayFeedsPanel: true,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -289,7 +289,7 @@ export const atomFeeds = [
   },
   {
     title: 'Natural England - NCEA',
-    url: 'https://naturalengland.blog.gov.uk/category/natural-capital/feed/',
+    url: 'https://naturalengland.blog.gov.uk/category/NCEA/feed/',
   },
 ];
 


### PR DESCRIPTION
### What one thing this PR does?
Changed blog category from NCEA to Natural Capital in the Natural England Blogs API. Updated the About Us page to display the most recent Natural Capital blog posts

### Task details

- [NCEA-308 - Natural England blog not updating](https://dsp-support.atlassian.net/browse/NCEA-308)

### How do these changes look like?
![Screenshot from 2025-05-19 11-06-51](https://github.com/user-attachments/assets/e6f02aef-65b1-4d87-8aed-66b60cce3aeb)
![Screenshot from 2025-05-19 11-06-31](https://github.com/user-attachments/assets/670fd394-84e5-43d1-b9eb-e3cd25bd3280)


### Dev-tested in

1. Local environment

- [Feeds Page](http://localhost:4000/natural-capital-ecosystem-assessment/newsfeed)
- [About Page](http://localhost:4000/natural-capital-ecosystem-assessment/about)
