### PR TITLE
NCEA-317 Study period - temporal extent not displayed correctly or consistently

### DIFF
--- a/__tests__/routes/web/resultsBlock.spec.ts
+++ b/__tests__/routes/web/resultsBlock.spec.ts
@@ -93,8 +93,8 @@ describe('Results block template', () => {
         const resultItems = resultItemsBlock.children;
         expect(resultItems.length).toBe(searchResultsWithData.total);
         Array.from(resultItems).forEach((resultItem: any, index) => {
-          const startDateValue = searchResultsWithData?.items[index]?.studyPeriodStart ?? 'Unavailable';
-          const endDateValue = searchResultsWithData?.items[index]?.studyPeriodEnd ?? 'Unavailable';
+          const startDateValue = searchResultsWithData?.items[index]?.studyPeriodStart ?? '';
+          const endDateValue = searchResultsWithData?.items[index]?.studyPeriodEnd ?? '';
 
           expect(resultItem.querySelector('.search-result__heading')?.textContent?.trim()).toEqual(
             searchResultsWithData?.items[index]?.title,

--- a/src/utils/getGeneralTabData.ts
+++ b/src/utils/getGeneralTabData.ts
@@ -29,8 +29,8 @@ export const getStudyPeriodDetails = (dateRanges: any): string => {
   const endDate: string = endPosition ? formatDate(endPosition) : '';
 
   if (!startDate && !endDate) return '';
-  if (!startDate) return `${endDate} to ${endDate}`;
-  if (!endDate) return `${startDate} to ${startDate}`;
+  if (!startDate) return `${endDate}`;
+  if (!endDate) return `${startDate}`;
 
   return `${startDate} to ${endDate}`;
 };

--- a/src/views/partials/results/summary.njk
+++ b/src/views/partials/results/summary.njk
@@ -112,22 +112,14 @@
               <span class='start'>
                 {% if item.studyPeriodStart %}
                   {{ item.studyPeriodStart }}
-                {% else %}
-                  {{govukTag({
-                    text: "Unavailable",
-                    classes: "govuk-tag--grey tab-content-value__not-provided"
-                  })}}
                 {% endif %}
               </span>
-              <span>to</span>
+             {% if item.studyPeriodEnd %}
+               <span>to</span>
+             {% endif %}
               <span class='end'>
                 {% if item.studyPeriodEnd %}
                   {{ item.studyPeriodEnd }}
-                {% else %}
-                  {{govukTag({
-                    text: "Unavailable",
-                    classes: "govuk-tag--grey tab-content-value__not-provided"
-                  })}}
                 {% endif %}
               </span>
             </span>


### PR DESCRIPTION
### What one thing this PR does?
In more Info page, If Study period start date is present, show the start date. If only the end date is present, show the end date in 

### Task details

- [NCEA-317  - Study period - temporal extent not displayed correctly or consistently](https://dsp-support.atlassian.net/browse/NCEA-317)

### How do these changes look like?
![Screenshot from 2025-05-21 16-51-25](https://github.com/user-attachments/assets/678dd40a-bc18-48ba-96ad-821c2563c489)
![Screenshot from 2025-05-21 17-02-35](https://github.com/user-attachments/assets/470fdeeb-0738-4ea9-b8d2-7b497e3bcedd)


### Dev-tested in

1. Local environment

- [More Info(http://localhost:4000/natural-capital-ecosystem-assessment/search/3c72669a-1331-4930-a12d-b4f8032aa5cd?q=england+peat+map&jry=qs&pg=1&rpp=20&srt=most_relevant#general)