### PR TITLE
NCEA-324 'Full downloads and supporting documentation' table requires scrolling to view download link

### DIFF
--- a/src/assets/sass/templates/_details.scss
+++ b/src/assets/sass/templates/_details.scss
@@ -100,21 +100,6 @@
   border: 2px solid $govuk-text-colour;
 }
 
-.details-table-full {
-  border-collapse: collapse;
-  width: 100%;
-}
-.details-table-full th,
-.details-table-full td {
-  padding: 8px 0;
-  text-align: left;
-  vertical-align: top;
-}
-
-.details-table-full th {
-  padding-top: 0;
-}
-
 .details-table-hr {
   padding: 0 !important;
   border-bottom: 1px solid #b1b4b6;
@@ -125,3 +110,43 @@
     grid-template-columns: auto 1fr;
   }
 }
+
+.details-table-full {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.details-table-full th,
+.details-table-full td {
+  padding: 8px;
+  text-align: left;
+  vertical-align: top;
+  word-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.details-table-full td:nth-child(1) {
+  min-width: 250px;
+}
+
+.details-table-full td:nth-child(2) {
+  min-width: 60px;
+  width: 10%;
+}
+
+.details-table-full td:nth-child(3) {
+  min-width: 100px;
+  width: 20%;
+}
+
+@media (max-width: 600px) {
+  .details-table-full th,
+  .details-table-full td {
+    font-size: 14px;
+    padding: 8px;
+  }
+}
+
+


### PR DESCRIPTION
### What one thing this PR does?

Fixed unwanted scrollbar in Full Downloads and supporting Documentation section. Added min-width and enabled word wrapping for long text

A sample one-liner about this task.

### Task details

- [NCEA-324 - NCEA-324 'Full downloads and supporting documentation' table requires scrolling to view download link](https://dsp-support.atlassian.net/browse/NCEA-324)

### How do these changes look like?
![Habitat-Networks-England-Ancient-Semi-Natural-Woodland-Access-05-30-2025_02_27_PM](https://github.com/user-attachments/assets/2f1e1da5-020c-44d9-8863-524b1e211b8c)


### Dev-tested in

1. Local environment

- [Page name/link 1](url)