### PR TITLE
NCEA-341 Fix spacing issue between NCEA image and contribution text

### DIFF
--- a/src/assets/sass/templates/_results.scss
+++ b/src/assets/sass/templates/_results.scss
@@ -829,7 +829,6 @@
 
 .contribution {
   align-items: center;
-  column-gap: 10px;
   display: grid;
   grid-template-columns: 20% 80%;
   overflow: hidden;


### PR DESCRIPTION
### What one thing this PR does?

Resolved the visual glitch in the NCEA contribution section where an unintended gap caused an "AND cut" by removing the spacing between the NCEA image and the contribution text

### Task details

- [NCEA-341 - Fix spacing issue between NCEA image and contribution text](https://dsp-support.atlassian.net/browse/NCEA-341)

### How do these changes look like?
![Screenshot from 2025-06-24 06-35-05](https://github.com/user-attachments/assets/00ac8196-ca8d-4643-8110-9af43d488411)


### Dev-tested in

1. Local environment

- [Search Result Page](http://localhost:4000/natural-capital-ecosystem-assessment/search?q=ncea&jry=qs&pg=1&rpp=20&srt=most_relevant)