### PR TITLE
DCI-352 Archived/Retired records are returned when IncludeRetiredAndArchived is set to false

### DIFF
--- a/src/interfaces/queryBuilder.interface.ts
+++ b/src/interfaces/queryBuilder.interface.ts
@@ -163,7 +163,7 @@ interface IFilter {
   DataType: string | null;
   Formats: string[] | null;
   SearchTitleOnly: boolean;
-  RetiredAndArchived: boolean;
+  IncludeRetiredAndArchived: boolean;
   NCEAOnly: boolean;
 }
 

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -315,7 +315,7 @@ const generateSearchQuery = (searchFieldsObject: ISearchPayload, filters: ISearc
       DateRange: dateFilters,
       Licence: licence ?? null,
       Keywords: keywords ?? [],
-      RetiredAndArchived: retiredAndArchived ?? false,
+      IncludeRetiredAndArchived: retiredAndArchived ?? false,
       NCEAOnly: filters.nceaOnly,
       // !: None of the below are used in the UI.
       FileIdentifier: null,


### PR DESCRIPTION
### What one thing this PR does?

Updated the filter key name from RetiredAndArchived to IncludeRetiredAndArchived for search result filters

### Task details

- [DCI-352 - Archived/Retired records are returned when IncludeRetiredAndArchived is set to false](https://dsp-support.atlassian.net/browse/NCEA-352)

### Dev-tested in

1. Local environment

- [Search Results](http://localhost:4000/natural-capital-ecosystem-assessment/search?date-before=&date-after=&licence=&keywords=&retired-archived=true&scope=all&q=NCEA&jry=qs&pg=1&rpp=20&srt=most_relevant)