### PR TITLE
NCEA-353: Uncheck Include Retired & Archived records filters not working

### DIFF
--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -89,7 +89,10 @@ const appendMetaSearchParams = (filterParams) => {
   const params = new URLSearchParams(window.location.search);
 
   for (const [key, value] of params.entries()) {
-    if (!filterParams.has(key) && key !== 'parent[]') {
+    if (filterParams.has('retired-archived')) {
+      filterParams.set(key, value);
+    }
+    if (!filterParams.has(key) && key !== 'parent[]' && key !== 'retired-archived') {
       filterParams.set(key, value);
     }
     if (!!params.get('keywords')) {


### PR DESCRIPTION
Resolved an issue where the "Include Retired & Archived" filter remained selected even after being unchecked and applying filters. Now when the checkbox is unchecked and "Apply Filters" button is clicked, the filter is properly removed as expected.

### What one thing this PR does?

A sample one-liner about this task.

### Task details

- [DCI-353 - Uncheck Include Retired & Archived records filters not working](https://dsp-support.atlassian.net/browse/NCEA-353)
