### PR TITLE
NCEA-358 - 'Copy link' access option not working

### DIFF
--- a/public/scripts/moreInfo.js
+++ b/public/scripts/moreInfo.js
@@ -1,13 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   const baseUrl = isLocal ? 'https://environment-test.data.gov.uk' : window.location.origin;
 
-  document.getElementById('copyLink').addEventListener('click', async (event) => {
-    try {
-      const link = event.target.value;
-      await navigator.clipboard.writeText(link);
-    } catch (err) {
-      console.error('Clipboard write failed:', err);
-    }
+  document.querySelectorAll('.copy-link').forEach((button) => {
+    button.addEventListener('click', async (event) => {
+      try {
+        const link = event.target.value;
+
+        await navigator.clipboard.writeText(link);
+      } catch (err) {
+        console.error('Clipboard write failed:', err);
+      }
+    });
   });
 
   const buttons = document.querySelectorAll('.download-resource');

--- a/src/utils/getAccessTabData.ts
+++ b/src/utils/getAccessTabData.ts
@@ -233,8 +233,7 @@ const createTableRow = (name: string, url: string) => {
     <td>${dataSetName}</td>
     <td>
       <button
-        id="copyLink"
-        class="govuk-button copy-link-btn"
+        class="govuk-button copy-link-btn copy-link"
         value="${url}"
         data-module="govuk-button"
       >


### PR DESCRIPTION
### What one thing this PR does?
Removed id="copyLink" and add a new class copy-link and updated the js to bind events to all the copy link buttons. This will ensure that  copy to clipboard functionality should work for all the rows in the table

### Task details

- [NCEA-358 - 'Copy link' access option not working](https://dsp-support.atlassian.net/browse/DCI-446)

### Dev-tested in

1. Local environment

- [MoreInfo](http://localhost:4000/natural-capital-ecosystem-assessment/search/9c41b3c6-2453-44f6-9900-e7821f1a1072?date-before=&date-after=&licence=&keywords=&scope=ncea&q=trees&jry=qs&pg=1&rpp=20&srt=most_relevant#access)