### PR TITLE
NCEA-358 - Update action column rendering for WFS/WMS servicesTypes

### DIFF
--- a/__tests__/utils/getAccessTabData.spec.ts
+++ b/__tests__/utils/getAccessTabData.spec.ts
@@ -35,11 +35,29 @@ describe('getAccessTabData functions', () => {
         MORE_INFO_MOCK_DATA.resources,
         'c9d7e118-d057-48f9-b520-76de8e51e014',
       );
-      expect(output).toContain('<td>Living England Segmentation (2019) Download</td>');
+      expect(output).toContain('<td>Download data by area of interest and format</td>');
       expect(output).toContain('<td>Living England Segmentation (2019) WFS</td>');
       expect(output).toContain('<td>Living England Segmentation (2019) REST Map Service</td>');
       expect(output).toContain('<td>Living England Segmentation (2019) WMS</td>');
       expect(output).toContain('<td>Natural England Open Data Geoportal dataset page</td>');
+    });
+
+    it('should return preview in action column if the url contains wms', () => {
+      const output = generateResourceWebsiteTable(
+        MORE_INFO_MOCK_DATA.resources,
+        'c9d7e118-d057-48f9-b520-76de8e51e014',
+      );
+      expect(output).toContain(
+        '<a class="govuk-link" href="/explore/c9d7e118-d057-48f9-b520-76de8e51e014" target="_blank">Preview<span class="govuk-visually-hidden">(opens in a new tab)</span></a>',
+      );
+    });
+
+    it('should return N/A in action column if the url contains wfs', () => {
+      const output = generateResourceWebsiteTable(
+        MORE_INFO_MOCK_DATA.resources,
+        'c9d7e118-d057-48f9-b520-76de8e51e014',
+      );
+      expect(output).toContain('<td>N/A</td>');
     });
   });
 


### PR DESCRIPTION
### What one thing this PR does?

Show "N/A" in the action col if serviceType is WFS. Show "Preview" with 'explore/{recordId}' if serviceType is WMS.
For the resources with `download=true` in the url, set label to "Download by area of interest and format" and set "Copy Link" action to "NA"

### Task details

- [NCEA-358 - Update action column rendering for WFS/WMS servicesTypes](https://dsp-support.atlassian.net/browse/NCEA-358)

### How do these changes look like?
**NCEA**
<img width="1572" height="975" alt="Screenshot 2025-10-06 102211" src="https://github.com/user-attachments/assets/89b43100-0a6a-460a-b206-6b889b32175f" />

**Live DSP**
<img width="1854" height="699" alt="Screenshot 2025-10-06 102243" src="https://github.com/user-attachments/assets/30e07f41-e7b8-48e2-941d-ad80bfe0a039" />


### Dev-tested in

1. Local environment
Set SEARCH_API=https://environment.data.gov.uk/api/search in env variables file
- [More Info](http://localhost:4000/natural-capital-ecosystem-assessment/search/9c41b3c6-2453-44f6-9900-e7821f1a1072?q=National+trees+outside+woodland+map&jry=qs&pg=1&rpp=20&srt=most_relevant#access)