### PR TITLE
fix(pages): Implemented code changes to fix duplicate keywords value

### DIFF
--- a/src/utils/getGeneralTabData.ts
+++ b/src/utils/getGeneralTabData.ts
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import remarkHtml from 'remark-html';
 
 import { formatDate } from './dates';
+import { removeDuplicatesValues } from './queryStringHelper';
 import { IGeneralItem, ITemporalExtent } from '../interfaces/searchResponse.interface';
 
 export const getStudyPeriodDetails = (dateRanges: ITemporalExtent): string => {
@@ -30,7 +31,7 @@ const getGeneralTabData = (payload: IGeneralItem) => ({
   content: formatContent(payload?.abstract ?? ''),
   studyPeriod: payload?.temporalExtent ? getStudyPeriodDetails(payload.temporalExtent) : '',
   topicCategories: payload?.topicCategories?.join(', ') ?? '',
-  keywords: payload?.keywords?.join(', ') ?? '',
+  keywords: payload?.keywords ? removeDuplicatesValues(payload.keywords.join(', ').toLowerCase()) : '',
   language: payload?.metadata?.language?.toLocaleUpperCase() ?? '',
 });
 


### PR DESCRIPTION
### What one thing this PR does?

I have implemented code changes to fix duplicate keywords value under the General tab (More Info section of the dataset page). I removed duplicate values from the keywords node of the main payload before displaying them on the UI.

IssueID # NCEA-434

### Task details:

https://dsp-support.atlassian.net/browse/NCEA-434


### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment/search/58139ce6-63f9-4444-9f77-fc7b5dcc00d8?q=peat&jry=qs&pg=1&rpp=20&srt=most_relevant#general
