### PR TITLE
fix(pages): Implemented code to display the Distribution Format in NC…

### DIFF
--- a/__tests__/utils/getQualityTabData.spec.ts
+++ b/__tests__/utils/getQualityTabData.spec.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { IQuality } from '../../src/interfaces/searchResponse.interface';
+import { IQuality, IQualityItem } from '../../src/interfaces/searchResponse.interface';
 import { getQualityTabData, getRecordsDates, getDistributionFormats } from '../../src/utils/getQualityTabData';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 
@@ -31,7 +31,12 @@ describe('Quality tab fields', () => {
   });
 
   it('should call getDistributionFormats and create a list of distribution formats', () => {
-    const resources = [
+  const payload: IQualityItem = {
+    datasetReferenceDate: {
+      creation: '',
+      revision: '',
+    },
+    resources: [
       {
         url: 'https://environment-test.data.gov.uk/explore/9bceae16-607b-49d6-a980-289289fc4643?download=true',
         name: 'Living England Segmentation (2019) Download',
@@ -53,10 +58,29 @@ describe('Quality tab fields', () => {
         language: 'eng',
         distributionFormat: ['PDF'],
       },
-    ];
-    expect(getDistributionFormats(resources)).toEqual('ZIP, PDF');
+    ],
+      dataFormats: [],
+    };
+    expect(getDistributionFormats(payload)).toEqual('ZIP, PDF');
   });
-  it('should call getDistributionFormats and create a list of empty string if distributionFormat is null', () => {
-    expect(getDistributionFormats(MORE_INFO_MOCK_DATA.resources)).toEqual('');
+  
+  it('should return empty string when resource formats are empty and no fallback', () => {
+  const payload: IQualityItem = {
+    datasetReferenceDate: {
+      creation: '',
+      revision: '',
+    },
+    resources: [
+      {
+        url: '',
+        name: '',
+        type: '',
+        language: '',
+        distributionFormat: [''],
+      },
+    ],
+    dataFormats: [],
+    };
+    expect(getDistributionFormats(payload)).toEqual('');
   });
 });

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -139,6 +139,7 @@ export interface IQualityItem {
   datasetReferenceDate: IDataSetReferenceDate;
   license?: ILicenseItem;
   resources?: IResources[] | undefined;
+  dataFormats?: DataFormat[] | undefined;
 }
 
 export interface IQuality {
@@ -412,4 +413,9 @@ export interface NceaClassifier {
 
 export interface ServiceOptions {
   [key: string]: string;
+}
+
+export interface DataFormat {
+  name: string;
+  version?: string;
 }

--- a/src/utils/getQualityTabData.ts
+++ b/src/utils/getQualityTabData.ts
@@ -41,10 +41,19 @@ const getRecordsDates = (data: string): string => {
   return formatDate(data, false, false);
 };
 
-export const getDistributionFormats = (resources): string => {
-  if (resources?.length > 0) {
+export const getDistributionFormats = (payload: IQualityItem): string => {
+  const resources = payload?.resources ?? [];
+  if (resources.length > 0) {
     const formats = resources.flatMap((item) => item.distributionFormat || []).filter(Boolean);
-    return [...new Set(formats ?? [])].join(', ');
+    const resourceFormats = [...new Set(formats)].join(', ');
+    if (resourceFormats) {
+      return resourceFormats;
+    }
+    const dataFormats = payload?.dataFormats ?? [];
+    if (dataFormats.length > 0) {
+      const formats = dataFormats.map((format) => format.name).filter(Boolean);
+      return [...new Set(formats)].join(', ');
+    }
   }
   return '';
 };
@@ -55,7 +64,7 @@ const getQualityTabData = (payload: IQualityItem): IQuality => ({
   revisionInformation: getRecordsDates(payload?.datasetReferenceDate?.revision ?? ''),
   metadataDate: getRecordsDates(payload?.datasetReferenceDate?.metadata ?? ''),
   lineage: payload?.lineage ?? '',
-  available_formats: getDistributionFormats(payload.resources ?? []),
+  available_formats: getDistributionFormats(payload ?? []),
   frequency_of_update: payload?.license?.frequencyOfUpdate ?? payload?.license?.accrualPeriodicity,
   character_encoding: 'utf8',
 });


### PR DESCRIPTION
### What one thing this PR does?

Implemented code to display the Distribution Format in NCEA Quality Tab from the resource as the first priority. If it is not available, the Distribution Format will be displayed based on the new parameter added to the search API response.

IssueID # NCEA-435

### Task details

https://dsp-support.atlassian.net/browse/NCEA-435

### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment/search/63b748ee-22a4-42ca-8a34-20321f6ab8af?q=peat&jry=qs&pg=1&rpp=20&srt=most_relevant#quality