### PR TITLE
feat(moreinfo): Add distribution format handling for DSP and EIDC

### DIFF
--- a/__tests__/utils/getQualityTabData.spec.ts
+++ b/__tests__/utils/getQualityTabData.spec.ts
@@ -54,9 +54,56 @@ describe('Quality tab fields', () => {
         distributionFormat: ['PDF'],
       },
     ];
-    expect(getDistributionFormats(resources)).toEqual('ZIP, PDF');
+    expect(getDistributionFormats(resources, [])).toEqual('ZIP, PDF');
   });
+
   it('should call getDistributionFormats and create a list of empty string if distributionFormat is null', () => {
-    expect(getDistributionFormats(MORE_INFO_MOCK_DATA.resources)).toEqual('');
+    expect(getDistributionFormats(MORE_INFO_MOCK_DATA.resources, [])).toEqual('');
+  });
+
+  it('should call getDistributionFormats and fallback to dataFormats when resource formats are null', () => {
+    const resources = [
+      {
+        url: 'https://data-package.ceh.ac.uk/data/9e4451f8-23d3-40dc-9302-73e30ad3dd76',
+        name: 'Download a copy of this data',
+        type: 'EIDC Document',
+        language: 'eng',
+        distributionFormat: null,
+      },
+      {
+        url: 'https://data-package.ceh.ac.uk/sd/9e4451f8-23d3-40dc-9302-73e30ad3dd76.zip',
+        name: 'Supporting information available to assist in re-use of this dataset',
+        type: 'EIDC Document',
+        language: 'eng',
+        distributionFormat: null,
+      },
+      {
+        url: 'https://catalogue.ceh.ac.uk/maps/6372b558-ba64-4fbe-8766-019e01535b37?request=getCapabilities&service=wms',
+        name: 'This link returns a WMS GetCapabilities response in XML format',
+        type: 'EIDC Document',
+        language: 'eng',
+        distributionFormat: null,
+      },
+    ];
+
+    const dataFormats = [
+      {
+        dataFormat: 'Shapefile',
+        version: 'unknown',
+      },
+    ];
+
+    expect(getDistributionFormats(resources, dataFormats)).toEqual('Shapefile');
+  });
+
+  it('should call getDistributionFormats and fallback to dataFormats when resources are empty', () => {
+    const dataFormats = [
+      {
+        dataFormat: 'Shapefile',
+        version: 'unknown',
+      },
+    ];
+
+    expect(getDistributionFormats([], dataFormats)).toEqual('Shapefile');
   });
 });

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -132,6 +132,10 @@ export interface IRecordDates {
   metadata?: null | undefined | string;
 }
 
+interface IDataFormat {
+  dataFormat: string;
+}
+
 export interface IQualityItem {
   metadataDate?: string;
   lineage?: string;
@@ -139,6 +143,7 @@ export interface IQualityItem {
   datasetReferenceDate: IDataSetReferenceDate;
   license?: ILicenseItem;
   resources?: IResources[] | undefined;
+  dataFormats?: IDataFormat[] | undefined;
 }
 
 export interface IQuality {
@@ -315,6 +320,7 @@ export interface IResources {
   language: string | null;
   distributionFormat?: undefined | null | [string];
 }
+
 interface SpatialItem {
   dataService?: string;
   representationService?: string;

--- a/src/utils/getQualityTabData.ts
+++ b/src/utils/getQualityTabData.ts
@@ -41,11 +41,23 @@ const getRecordsDates = (data: string): string => {
   return formatDate(data, false, false);
 };
 
-export const getDistributionFormats = (resources): string => {
-  if (resources?.length > 0) {
-    const formats = resources.flatMap((item) => item.distributionFormat || []).filter(Boolean);
-    return [...new Set(formats ?? [])].join(', ');
+const getUniqueFormats = (formats: string[]): string => {
+  return [...new Set(formats)].join(', ');
+};
+
+export const getDistributionFormats = (resources, dataFormats): string => {
+  const resourceFormats = (resources ?? []).flatMap((item) => item.distributionFormat || []).filter(Boolean);
+
+  if (resourceFormats.length > 0) {
+    return getUniqueFormats(resourceFormats);
   }
+
+  const fallbackFormats = (dataFormats ?? []).map((item) => item?.dataFormat).filter(Boolean);
+
+  if (fallbackFormats.length > 0) {
+    return getUniqueFormats(fallbackFormats);
+  }
+
   return '';
 };
 
@@ -55,7 +67,7 @@ const getQualityTabData = (payload: IQualityItem): IQuality => ({
   revisionInformation: getRecordsDates(payload?.datasetReferenceDate?.revision ?? ''),
   metadataDate: getRecordsDates(payload?.datasetReferenceDate?.metadata ?? ''),
   lineage: payload?.lineage ?? '',
-  available_formats: getDistributionFormats(payload.resources ?? []),
+  available_formats: getDistributionFormats(payload.resources ?? [], payload?.dataFormats ?? []),
   frequency_of_update: payload?.license?.frequencyOfUpdate ?? payload?.license?.accrualPeriodicity,
   character_encoding: 'utf8',
 });


### PR DESCRIPTION
Implemented distribution format support for DSP and EIDC datasets. Priorities distributionFormats from resources. If the resources distribution is null then it will take the data formats and show as comma, sperated values.

IssueID NCEA-435

