### PR TITLE
fix(pages): Fix the child section alignment issue

### DIFF
--- a/public/css/tree_view.css
+++ b/public/css/tree_view.css
@@ -339,11 +339,15 @@
 }
 
 
+.no-parents~.child-section {
+  margin-left: -1em;
+}
+
 @media (max-width: 768px) {
 
   .single-parents-section .relation-tree li div a,
   .single-childs-section .relation-tree li div a {
     display: table-caption;
-    width: 100vw;
+    width: calc(90vw - 80px);
   }
 }

--- a/public/scripts/treeView.js
+++ b/public/scripts/treeView.js
@@ -132,7 +132,12 @@ function updateTreeStyles() {
       }
       parentSections[0]?.classList.add('parent-level-1-grand', 'single-l0-multiple-l1-no-l2');
     } else {
-      parentSections[0]?.classList.add('parent-level-1-grand');
+      if (totalParentLevel0Count === 0) {
+        parentSections[0]?.classList.add('no-parents');
+      } else {
+        parentSections[0]?.classList.add('parent-level-1-grand');
+      }
+
     }
   }
 


### PR DESCRIPTION
For no parent nodes, the child nodes section should be aligned to towards the left to -1em, so this case is consitence with the other cases. The line is start at the word of the parent.

Also fix the text responsive issue, in small screens the horizontal scroll is appearing, its fixed now.
