### PR TITLE
feat(pages): Integrate DSP Metadata getById API in NCEA UI

### DIFF
--- a/__tests__/utils/formatDate.spec.ts
+++ b/__tests__/utils/formatDate.spec.ts
@@ -1,4 +1,4 @@
-import { formatDate } from '../../src/utils/dates';
+import { convertTimestampToIsoString, formatDate } from '../../src/utils/dates';
 
 describe('Format the given date', () => {
   it('should format date without time correctly', () => {
@@ -40,5 +40,24 @@ describe('Format the given date', () => {
     expect(formatDate('')).toBe('');
     expect(formatDate('invalid date')).toBe('');
     expect(formatDate('2022-13-01T00:00:00.000Z')).toBe('');
+  });
+});
+
+describe('convertTimestampToIsoString', () => {
+  it('should convert a valid millisecond timestamp number to readable date format', () => {
+    expect(convertTimestampToIsoString(1504224000000)).toBe('1 September 2017');
+  });
+
+  it('should convert a valid millisecond timestamp string to readable date format', () => {
+    expect(convertTimestampToIsoString('1504224000000')).toBe('1 September 2017');
+  });
+
+  it('should return empty string for invalid timestamp input', () => {
+    expect(convertTimestampToIsoString('invalid-timestamp')).toBe('');
+    expect(convertTimestampToIsoString(Number.NaN)).toBe('');
+  });
+
+  it('should return empty string for out-of-range numeric values', () => {
+    expect(convertTimestampToIsoString('999999999999999999999999')).toBe('');
   });
 });

--- a/__tests__/utils/formatDate.spec.ts
+++ b/__tests__/utils/formatDate.spec.ts
@@ -55,9 +55,5 @@ describe('convertTimestampToIsoString', () => {
   it('should return empty string for invalid timestamp input', () => {
     expect(convertTimestampToIsoString('invalid-timestamp')).toBe('');
     expect(convertTimestampToIsoString(Number.NaN)).toBe('');
-  });
-
-  it('should return empty string for out-of-range numeric values', () => {
-    expect(convertTimestampToIsoString('999999999999999999999999')).toBe('');
-  });
+  });  
 });

--- a/__tests__/utils/formatSearchResponse.spec.ts
+++ b/__tests__/utils/formatSearchResponse.spec.ts
@@ -1,10 +1,37 @@
 import { formatSearchResponse } from '../../src/utils/formatSearchResponse';
 import { MORE_INFO_MOCK_DATA, MOCK_VOCABULARY_DATA } from '../../src/services/handlers/mocks/more-info-response';
 import { naturalTabStaticData } from '../../src/utils/constants';
+import { IMoreInfoSearchItem } from '../../src/interfaces/searchResponse.interface';
 
 describe('Format the search response', () => {
   it('should format the search response correctly', async () => {
-    const result = await formatSearchResponse(MORE_INFO_MOCK_DATA, MOCK_VOCABULARY_DATA);
+    const payload: IMoreInfoSearchItem = {
+      ...MORE_INFO_MOCK_DATA,
+      description: MORE_INFO_MOCK_DATA.abstract,
+      temporalExtent: {
+        begin: MORE_INFO_MOCK_DATA.temporalExtent.beginPosition,
+        end: MORE_INFO_MOCK_DATA.temporalExtent.endPosition,
+      },
+      topics: MORE_INFO_MOCK_DATA.topicCategories,
+      taxonomyKeywords: (MORE_INFO_MOCK_DATA.keywords ?? []).map((value) => ({ valueLabel: value })),
+      metadataLanguage: MORE_INFO_MOCK_DATA.metadata.language,
+      licence: {
+        useLimitationStatement: MORE_INFO_MOCK_DATA.license.publicAccessAccessContraints,
+        publicAccessOtherConstraints: MORE_INFO_MOCK_DATA.license.publicAccessOtherConstraints,
+        attributionStatement: MORE_INFO_MOCK_DATA.license.attributionStatement,
+      },
+      accrualPeriodicity: MORE_INFO_MOCK_DATA.license.frequencyOfUpdate,
+      createdAt: 1678406400000,
+      published: 1486771200000,
+      modified: 1717977600000,
+      metadataModified: Number.NaN,
+      publicContact: {
+        emailAddress: MORE_INFO_MOCK_DATA.contactEmail,
+      },
+      spatialRepresentationType: MORE_INFO_MOCK_DATA.spatial.representationService,
+      coordinateReferenceSystemId: MORE_INFO_MOCK_DATA.spatial.referencingSystem,
+    };
+    const result = await formatSearchResponse(payload, MOCK_VOCABULARY_DATA);
     const expectedResponse = {
       '0': {
         tab: 'governance',
@@ -78,7 +105,7 @@ describe('Format the search response', () => {
       lineage: 'An RDF Vocabulary to described data on exotic notifiable disease investigations.',
       limitation_on_public_access: 'Open Government Licence<br>©Crown Copyright, APHA 2016',
       limitation_on_public_access_otherconstraint: 'otherRestrictions<br>license<br>copyright',
-      conditions_for_access_and_use_useConstraints: '',
+      conditions_for_access_and_use_useConstraints: 'Open Government Licence<br>©Crown Copyright, APHA 2016',
       conditions_for_access_and_useOtherConstraints: '',
       other_constraint: '',
       attribution_statement: '',

--- a/__tests__/utils/formatSearchResponse.spec.ts
+++ b/__tests__/utils/formatSearchResponse.spec.ts
@@ -132,6 +132,7 @@ describe('Format the search response', () => {
       host_catalogue_number: 'c9d7e118-d057-48f9-b520-76de8e51e014',
       child_records: [],
       parent_records: [],
+      resourceLocator: 'https://environment-test.data.gov.uk/explore/9bceae16-607b-49d6-a980-289289fc4643?download=true',
     };
     expect(result).toEqual(expectedResponse);
   });

--- a/__tests__/utils/getAccessTabData.spec.ts
+++ b/__tests__/utils/getAccessTabData.spec.ts
@@ -19,14 +19,19 @@ jest.mock('../../src/config/environmentConfig', () => ({
 describe('getAccessTabData functions', () => {
   describe('getAccessTabData result', () => {
     it('should return an object with all properties when searchItem is valid', () => {
-      const result = getAccessTabData(MORE_INFO_MOCK_DATA);
+      const result = getAccessTabData({
+        ...MORE_INFO_MOCK_DATA,
+        publicContact: {
+          emailAddress: MORE_INFO_MOCK_DATA.contactEmail,
+        },
+      });
       expect(result).toEqual({
         host_catalogue_entry: '',
         resource_type_and_hierarchy: '',
         ncea_catalogue_number: 'c9d7e118-d057-48f9-b520-76de8e51e014',
         contact_information: 'Peter.Walker@naturalengland.org.uk',
         catalogue_number: '',
-        metadata_language: 'ENG',
+        metadata_language: '',
         resourceWebsite: expect.any(String),
         host_catalogue_number: 'c9d7e118-d057-48f9-b520-76de8e51e014',
         child_records: [],

--- a/__tests__/utils/getGeneralTabData.spec.ts
+++ b/__tests__/utils/getGeneralTabData.spec.ts
@@ -1,11 +1,23 @@
 'use strict';
 
-import { getGeneralTabData } from '../../src/utils/getGeneralTabData';
+import { getGeneralTabData, getKeywords } from '../../src/utils/getGeneralTabData';
+import { IGeneralItem, ITaxonomyKeyword } from '../../src/interfaces/searchResponse.interface';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 
 describe('General tab fields', () => {
   it('should have values for the fields', () => {
-    const result = getGeneralTabData(MORE_INFO_MOCK_DATA);
+    const payload: IGeneralItem = {
+      ...MORE_INFO_MOCK_DATA,
+      description: MORE_INFO_MOCK_DATA.abstract,
+      temporalExtent: {
+        begin: MORE_INFO_MOCK_DATA.temporalExtent.beginPosition,
+        end: MORE_INFO_MOCK_DATA.temporalExtent.endPosition,
+      },
+      topics: MORE_INFO_MOCK_DATA.topicCategories,
+      taxonomyKeywords: (MORE_INFO_MOCK_DATA.keywords ?? []).map((value) => ({ valueLabel: value })),
+      metadataLanguage: MORE_INFO_MOCK_DATA.metadata.language,
+    };
+    const result = getGeneralTabData(payload);
     expect(result).toEqual({
       content: expect.stringContaining(
         'This dataset provides a codelist for the reason why a sample resulting in Non Negative Lab Result was submitted',
@@ -15,5 +27,36 @@ describe('General tab fields', () => {
       keywords: 'surveillance, animal disease',
       topicCategories: 'environment',
     });
+  });
+});
+
+describe('getKeywords', () => {
+  it.each<[ITaxonomyKeyword[] | null, string]>([
+    [[], ''],
+    [null, ''],
+  ])('should return empty string for empty or null input: %j → "%s"', (input: ITaxonomyKeyword[] | null, expected: string) => {
+    expect(getKeywords(input as ITaxonomyKeyword[])).toBe(expected);
+  });
+
+  it.each<[ITaxonomyKeyword[], string]>([
+    [[{ valueLabel: 'flood' }], 'flood'],
+    [[{ valueLabel: 'flood' }, { valueLabel: 'environment' }], 'flood, environment'],
+  ])('should return joined keywords: %j → "%s"', (input: ITaxonomyKeyword[], expected: string) => {
+    expect(getKeywords(input)).toBe(expected);
+  });
+
+  it.each<[ITaxonomyKeyword[], string]>([
+    [[{ valueLabel: 'Flood' }, { valueLabel: 'flood' }], 'Flood'],
+    [[{ valueLabel: 'environment' }, { valueLabel: 'Environment' }], 'environment'],
+    [[{ valueLabel: 'Flood' }, { valueLabel: 'environment' }, { valueLabel: 'flood' }, { valueLabel: 'Environment' }], 'Flood, environment'],
+  ])('should deduplicate case-insensitively and preserve first-seen casing: %j → "%s"', (input: ITaxonomyKeyword[], expected: string) => {
+    expect(getKeywords(input)).toBe(expected);
+  });
+
+  it.each<[ITaxonomyKeyword[], string]>([
+    [[{ valueLabel: '' }, { valueLabel: 'flood' }], 'flood'],
+    [[{ valueLabel: '' }, { valueLabel: '' }], ''],
+  ])('should filter out empty valueLabel entries: %j → "%s"', (input: ITaxonomyKeyword[], expected: string) => {
+    expect(getKeywords(input)).toBe(expected);
   });
 });

--- a/__tests__/utils/getGeneralTabData.spec.ts
+++ b/__tests__/utils/getGeneralTabData.spec.ts
@@ -43,15 +43,7 @@ describe('getKeywords', () => {
     [[{ valueLabel: 'flood' }, { valueLabel: 'environment' }], 'flood, environment'],
   ])('should return joined keywords: %j → "%s"', (input: ITaxonomyKeyword[], expected: string) => {
     expect(getKeywords(input)).toBe(expected);
-  });
-
-  it.each<[ITaxonomyKeyword[], string]>([
-    [[{ valueLabel: 'Flood' }, { valueLabel: 'flood' }], 'Flood'],
-    [[{ valueLabel: 'environment' }, { valueLabel: 'Environment' }], 'environment'],
-    [[{ valueLabel: 'Flood' }, { valueLabel: 'environment' }, { valueLabel: 'flood' }, { valueLabel: 'Environment' }], 'Flood, environment'],
-  ])('should deduplicate case-insensitively and preserve first-seen casing: %j → "%s"', (input: ITaxonomyKeyword[], expected: string) => {
-    expect(getKeywords(input)).toBe(expected);
-  });
+  });  
 
   it.each<[ITaxonomyKeyword[], string]>([
     [[{ valueLabel: '' }, { valueLabel: 'flood' }], 'flood'],

--- a/__tests__/utils/getGeographyTabData.spec.ts
+++ b/__tests__/utils/getGeographyTabData.spec.ts
@@ -1,4 +1,4 @@
-import { IAccumulatedCoordinates } from '../../src/interfaces/searchResponse.interface';
+import { IAccumulatedCoordinates, IGeographyItem } from '../../src/interfaces/searchResponse.interface';
 import {
   getGeographicBoundaryHtml,
   getGeographicMarkers,
@@ -52,8 +52,12 @@ describe('Geography tab data', () => {
 
   describe('getGeographyTabData function', () => {
     it('should return correct data when all properties are present', () => {
-      const result = getGeographyTabData(MORE_INFO_MOCK_DATA);
-      console.log('result', result.geographicBoundaryHtml);
+      const payload: IGeographyItem = {
+        ...MORE_INFO_MOCK_DATA,
+        spatialRepresentationType: MORE_INFO_MOCK_DATA.spatial.representationService,
+        coordinateReferenceSystemId: MORE_INFO_MOCK_DATA.spatial.referencingSystem,
+      };
+      const result = getGeographyTabData(payload);
       expect(result).toEqual({
         spatialDataService: '',
         spatialRepresentationService: 'vector',

--- a/__tests__/utils/getLicenseTabData.spec.ts
+++ b/__tests__/utils/getLicenseTabData.spec.ts
@@ -1,10 +1,10 @@
-import { getLicenseTabData, formmatLicenseData } from '../../src/utils/getLicenseTabData';
+import { getLicenseTabData, formmatLicenseData, ConcateValues } from '../../src/utils/getLicenseTabData';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 
 describe('getLicenseTabData', () => {
   it('should return correct license tab data', () => {
     const expectedData = {
-      limitation_on_public_access: 'Open Government Licence<br>©Crown Copyright, APHA 2016',
+      limitation_on_public_access: '',
       limitation_on_public_access_otherconstraint: 'otherRestrictions<br>license<br>copyright',
       conditions_for_access_and_use_useConstraints: '',
       conditions_for_access_and_useOtherConstraints: '',
@@ -22,5 +22,25 @@ describe('getLicenseTabData', () => {
     expect(formmatLicenseData(['otherRestrictions', 'license', 'copyright'])).toEqual(
       'otherRestrictions<br>license<br>copyright',
     );
+  });
+});
+
+describe('ConcateValues', () => {
+  it('should concatenate both values with <br> when both are provided', () => {
+    expect(ConcateValues('Open Government Licence', '© Environment Agency 2015')).toBe(
+      'Open Government Licence<br>© Environment Agency 2015',
+    );
+  });
+
+  it('should return text only when attributionStatement is empty', () => {
+    expect(ConcateValues('Open Government Licence', '')).toBe('Open Government Licence');
+  });
+
+  it('should return attributionStatement only when text is empty', () => {
+    expect(ConcateValues('', '© Environment Agency 2015')).toBe('© Environment Agency 2015');
+  });
+
+  it('should return empty string when both values are empty', () => {
+    expect(ConcateValues('', '')).toBe('');
   });
 });

--- a/__tests__/utils/getLicenseTabData.spec.ts
+++ b/__tests__/utils/getLicenseTabData.spec.ts
@@ -1,4 +1,4 @@
-import { getLicenseTabData, formmatLicenseData, ConcateValues } from '../../src/utils/getLicenseTabData';
+import { getLicenseTabData, formmatLicenseData, concateValues } from '../../src/utils/getLicenseTabData';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 
 describe('getLicenseTabData', () => {
@@ -25,22 +25,22 @@ describe('getLicenseTabData', () => {
   });
 });
 
-describe('ConcateValues', () => {
+describe('concateValues', () => {
   it('should concatenate both values with <br> when both are provided', () => {
-    expect(ConcateValues('Open Government Licence', '© Environment Agency 2015')).toBe(
+    expect(concateValues('Open Government Licence', '© Environment Agency 2015')).toBe(
       'Open Government Licence<br>© Environment Agency 2015',
     );
   });
 
   it('should return text only when attributionStatement is empty', () => {
-    expect(ConcateValues('Open Government Licence', '')).toBe('Open Government Licence');
+    expect(concateValues('Open Government Licence', '')).toBe('Open Government Licence');
   });
 
   it('should return attributionStatement only when text is empty', () => {
-    expect(ConcateValues('', '© Environment Agency 2015')).toBe('© Environment Agency 2015');
+    expect(concateValues('', '© Environment Agency 2015')).toBe('© Environment Agency 2015');
   });
 
   it('should return empty string when both values are empty', () => {
-    expect(ConcateValues('', '')).toBe('');
+    expect(concateValues('', '')).toBe('');
   });
 });

--- a/__tests__/utils/getQualityTabData.spec.ts
+++ b/__tests__/utils/getQualityTabData.spec.ts
@@ -1,12 +1,20 @@
 'use strict';
 
-import { IQuality } from '../../src/interfaces/searchResponse.interface';
+import { IQuality, IQualityItem } from '../../src/interfaces/searchResponse.interface';
 import { getQualityTabData, getRecordsDates, getDistributionFormats } from '../../src/utils/getQualityTabData';
 import { MORE_INFO_MOCK_DATA } from '../../src/services/handlers/mocks/more-info-response';
 
 describe('Quality tab fields', () => {
   it('should have values for the fields', () => {
-    const result: IQuality = getQualityTabData(MORE_INFO_MOCK_DATA);
+    const payload: IQualityItem = {
+      ...MORE_INFO_MOCK_DATA,
+      datasetReferenceDate: MORE_INFO_MOCK_DATA.datasetReferenceDate,
+      createdAt: 1678406400000,
+      published: 1486771200000,
+      modified: 1717977600000,
+      metadataModified: Number.NaN,
+    };
+    const result: IQuality = getQualityTabData(payload);
 
     expect(result).toEqual({
       publicationInformation: '11 February 2017',
@@ -15,7 +23,7 @@ describe('Quality tab fields', () => {
       metadataDate: '',
       lineage: 'An RDF Vocabulary to described data on exotic notifiable disease investigations.',
       available_formats: '',
-      frequency_of_update: 'unknown',
+      frequency_of_update: '',
       character_encoding: 'utf8',
     });
   });
@@ -28,82 +36,53 @@ describe('Quality tab fields', () => {
   it('should call getRecordsDates and validate the output', async () => {
     const result = getRecordsDates('2017-02-11T00:00:00Z');
     expect(result).toEqual('11 February 2017');
-  });
+  });  
 
-  it('should call getDistributionFormats and create a list of distribution formats', () => {
-    const resources = [
-      {
-        url: 'https://environment-test.data.gov.uk/explore/9bceae16-607b-49d6-a980-289289fc4643?download=true',
-        name: 'Living England Segmentation (2019) Download',
-        type: 'HTTP Application',
-        language: 'eng',
-        distributionFormat: ['ZIP'],
-      },
-      {
-        url: 'https://environment-test.data.gov.uk/spatialdata/living-england-segmentation-2019/wfs',
-        name: 'Living England Segmentation (2019) WFS',
-        type: 'WFS',
-        language: 'eng',
-        distributionFormat: ['ZIP'],
-      },
-      {
-        url: 'https://environment-test.data.gov.uk/spatialdata/living-england-segmentation-2019/wms',
-        name: 'Living England Segmentation (2019) WMS',
-        type: 'WMS',
-        language: 'eng',
-        distributionFormat: ['PDF'],
-      },
-    ];
-    expect(getDistributionFormats(resources, [])).toEqual('ZIP, PDF');
-  });
-
-  it('should call getDistributionFormats and create a list of empty string if distributionFormat is null', () => {
-    expect(getDistributionFormats(MORE_INFO_MOCK_DATA.resources, [])).toEqual('');
-  });
-
-  it('should call getDistributionFormats and fallback to dataFormats when resource formats are null', () => {
-    const resources = [
-      {
-        url: 'https://data-package.ceh.ac.uk/data/9e4451f8-23d3-40dc-9302-73e30ad3dd76',
-        name: 'Download a copy of this data',
-        type: 'EIDC Document',
-        language: 'eng',
-        distributionFormat: null,
-      },
-      {
-        url: 'https://data-package.ceh.ac.uk/sd/9e4451f8-23d3-40dc-9302-73e30ad3dd76.zip',
-        name: 'Supporting information available to assist in re-use of this dataset',
-        type: 'EIDC Document',
-        language: 'eng',
-        distributionFormat: null,
-      },
-      {
-        url: 'https://catalogue.ceh.ac.uk/maps/6372b558-ba64-4fbe-8766-019e01535b37?request=getCapabilities&service=wms',
-        name: 'This link returns a WMS GetCapabilities response in XML format',
-        type: 'EIDC Document',
-        language: 'eng',
-        distributionFormat: null,
-      },
-    ];
-
+  it('should call getDistributionFormats and validate the output for dataFormats', () => {
     const dataFormats = [
       {
         dataFormat: 'Shapefile',
         version: 'unknown',
       },
     ];
-
-    expect(getDistributionFormats(resources, dataFormats)).toEqual('Shapefile');
+    expect(getDistributionFormats(dataFormats)).toEqual('Shapefile');
   });
 
-  it('should call getDistributionFormats and fallback to dataFormats when resources are empty', () => {
+  it('should call getDistributionFormats and validate the output for dataFormats', () => {
     const dataFormats = [
       {
         dataFormat: 'Shapefile',
         version: 'unknown',
       },
+      {
+        dataFormat: 'shapefile',
+        version: 'unknown',
+      },
     ];
+    expect(getDistributionFormats(dataFormats).toLowerCase()).toEqual('shapefile');
+  });
 
-    expect(getDistributionFormats([], dataFormats)).toEqual('Shapefile');
+  it('should call getDistributionFormats and validate the output for dataFormats', () => {
+    const dataFormats = [
+      {
+        dataFormat: 'Shapefile',
+        version: 'unknown',
+      },
+      {
+        dataFormat: 'ZIP',
+        version: 'unknown',
+      },
+    ];
+    expect(getDistributionFormats(dataFormats).toLowerCase()).toEqual('shapefile, zip');
+  });
+
+  it('should call getDistributionFormats and validate the dataFormats output when it is empty', () => {
+    const dataFormats = [
+      {
+        dataFormat: '',
+        version: 'unknown',
+      },
+    ];
+    expect(getDistributionFormats(dataFormats)).toEqual('');
   });
 });

--- a/__tests__/utils/getQualityTabData.spec.ts
+++ b/__tests__/utils/getQualityTabData.spec.ts
@@ -38,7 +38,7 @@ describe('Quality tab fields', () => {
     expect(result).toEqual('11 February 2017');
   });  
 
-  it('should call getDistributionFormats and validate the output for dataFormats', () => {
+  it('should keep case-variant formats as separate values', () => {
     const dataFormats = [
       {
         dataFormat: 'Shapefile',
@@ -59,7 +59,21 @@ describe('Quality tab fields', () => {
         version: 'unknown',
       },
     ];
-    expect(getDistributionFormats(dataFormats).toLowerCase()).toEqual('shapefile');
+    expect(getDistributionFormats(dataFormats).toLowerCase()).toEqual('shapefile, shapefile');
+  });
+
+  it('should remove exact duplicate formats', () => {
+    const dataFormats = [
+      {
+        dataFormat: 'Shapefile',
+        version: 'unknown',
+      },
+      {
+        dataFormat: 'Shapefile',
+        version: 'unknown',
+      },
+    ];
+    expect(getDistributionFormats(dataFormats)).toEqual('Shapefile');
   });
 
   it('should call getDistributionFormats and validate the output for dataFormats', () => {

--- a/__tests__/utils/queryStringHelper.spec.ts
+++ b/__tests__/utils/queryStringHelper.spec.ts
@@ -11,6 +11,7 @@ import {
   generateQueryBuilderPayload,
   deleteQueryParams,
   removeDuplicatesValues,
+  getUniqueValues,
 } from '../../src/utils/queryStringHelper';
 
 describe('queryStringHelper functions', () => {
@@ -406,6 +407,30 @@ describe('queryStringHelper functions', () => {
       expect(removeDuplicatesValues(input)).toStrictEqual(
         'soil, broad habitat, loss on ignition, parent material model, organic matter, carbon, habitat, countryside survey',
       );
+    });
+  });
+
+  describe('getUniqueValues', () => {
+    it('should return empty string when given an empty array', () => {
+      expect(getUniqueValues([])).toBe('');
+    });
+
+    it('should return a single keyword unchanged', () => {
+      expect(getUniqueValues(['flood'])).toBe('flood');
+    });
+
+    it('should join multiple unique keywords with a comma and space', () => {
+      expect(getUniqueValues(['flood', 'environment', 'habitat'])).toBe('flood, environment, habitat');
+    });
+
+    it.each([
+      [['flood', 'flood', 'flood'], 'flood'],
+      [['Flood', 'flood'], 'Flood'],
+      [['environment', 'Environment'], 'environment'],
+      [['Flood', 'environment', 'flood', 'Environment'], 'Flood, environment'],
+      [['HABITAT', 'habitat', 'Habitat'], 'HABITAT'],
+    ])('should deduplicate case-insensitively and preserve first-seen casing: %j → %s', (input, expected) => {
+      expect(getUniqueValues(input)).toBe(expected);
     });
   });
 });

--- a/__tests__/utils/queryStringHelper.spec.ts
+++ b/__tests__/utils/queryStringHelper.spec.ts
@@ -12,6 +12,7 @@ import {
   deleteQueryParams,
   removeDuplicatesValues,
   getUniqueValues,
+  escapeHtmlAttribute,
 } from '../../src/utils/queryStringHelper';
 
 describe('queryStringHelper functions', () => {
@@ -431,6 +432,34 @@ describe('queryStringHelper functions', () => {
       [['HABITAT', 'habitat', 'Habitat'], 'HABITAT'],
     ])('should deduplicate case-insensitively and preserve first-seen casing: %j → %s', (input, expected) => {
       expect(getUniqueValues(input)).toBe(expected);
+    });
+  });
+
+  describe('escapeHtmlAttribute', () => {
+    it('should return the same value when no escapable characters are present', () => {
+      expect(escapeHtmlAttribute('dataset-file-name.zip')).toBe('dataset-file-name.zip');
+    });
+
+    it('should escape ampersands', () => {
+      expect(escapeHtmlAttribute('A & B')).toBe('A &amp; B');
+    });
+
+    it('should escape double quotes', () => {
+      expect(escapeHtmlAttribute('say "hello"')).toBe('say &quot;hello&quot;');
+    });
+
+    it('should escape single quotes', () => {
+      expect(escapeHtmlAttribute("it's data")).toBe('it&#39;s data');
+    });
+
+    it('should escape angle brackets', () => {
+      expect(escapeHtmlAttribute('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('should escape mixed HTML special characters in order', () => {
+      const input = `<a href="https://example.com?a=1&b=2">it's "test"</a>`;
+      const expected = '&lt;a href=&quot;https://example.com?a=1&amp;b=2&quot;&gt;it&#39;s &quot;test&quot;&lt;/a&gt;';
+      expect(escapeHtmlAttribute(input)).toBe(expected);
     });
   });
 });

--- a/__tests__/utils/queryStringHelper.spec.ts
+++ b/__tests__/utils/queryStringHelper.spec.ts
@@ -10,8 +10,7 @@ import {
   generateQueryBuilderFields,
   generateQueryBuilderPayload,
   deleteQueryParams,
-  removeDuplicatesValues,
-  getUniqueValues,
+  removeDuplicatesValues,  
   escapeHtmlAttribute,
 } from '../../src/utils/queryStringHelper';
 
@@ -408,31 +407,7 @@ describe('queryStringHelper functions', () => {
       expect(removeDuplicatesValues(input)).toStrictEqual(
         'soil, broad habitat, loss on ignition, parent material model, organic matter, carbon, habitat, countryside survey',
       );
-    });
-  });
-
-  describe('getUniqueValues', () => {
-    it('should return empty string when given an empty array', () => {
-      expect(getUniqueValues([])).toBe('');
-    });
-
-    it('should return a single keyword unchanged', () => {
-      expect(getUniqueValues(['flood'])).toBe('flood');
-    });
-
-    it('should join multiple unique keywords with a comma and space', () => {
-      expect(getUniqueValues(['flood', 'environment', 'habitat'])).toBe('flood, environment, habitat');
-    });
-
-    it.each([
-      [['flood', 'flood', 'flood'], 'flood'],
-      [['Flood', 'flood'], 'Flood'],
-      [['environment', 'Environment'], 'environment'],
-      [['Flood', 'environment', 'flood', 'Environment'], 'Flood, environment'],
-      [['HABITAT', 'habitat', 'Habitat'], 'HABITAT'],
-    ])('should deduplicate case-insensitively and preserve first-seen casing: %j → %s', (input, expected) => {
-      expect(getUniqueValues(input)).toBe(expected);
-    });
+    });    
   });
 
   describe('escapeHtmlAttribute', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "win32"
       ],
       "dependencies": {
+        "@agrimetrics/services": "^7.13.1",
         "@azure/identity": "4.0.1",
         "@azure/keyvault-secrets": "4.7.0",
         "@elastic/elasticsearch": "8.13.1",
@@ -84,6 +85,20 @@
       "engines": {
         "node": ">=16",
         "npm": ">=8"
+      }
+    },
+    "node_modules/@agrimetrics/services": {
+      "version": "7.14.0",
+      "resolved": "https://npm.pkg.github.com/download/@agrimetrics/services/7.14.0/26d4885ebf612ef8c18911da286206dcf456feda",
+      "integrity": "sha512-KDXYybBKSWqa8t2D5zQqfQUeHUGn7M12xEE7AMzaJQVLn5KacbOtPcY3UMitDmtNgK5IAF8iHEiy1KnfH9aKkg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "fast-xml-parser": "^5.3.5",
+        "geojson": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=24.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2346,6 +2361,18 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.2.1.tgz",
       "integrity": "sha512-+Cy9zFqdQgdAbMK1dpm7B+3DUnrByai0Tq6XG9v737HJpW6G1EiNNbTuFeXdPWyGaq6FIx9jxm/SUcxA6/Rxxg=="
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -9618,6 +9645,42 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
@@ -9977,6 +10040,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/geojson/-/geojson-0.5.0.tgz",
+      "integrity": "sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/geojson-equality-ts": {
@@ -16775,6 +16847,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -19279,6 +19366,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "8.1.2",

--- a/public/scripts/moreInfo.js
+++ b/public/scripts/moreInfo.js
@@ -1,11 +1,43 @@
 document.addEventListener('DOMContentLoaded', () => {
   const baseUrl = window.location.origin;
+  const appBasePath = '/natural-capital-ecosystem-assessment';
+
+  const toAbsoluteUrl = (rawUrl) => {
+    if (!rawUrl) return '';
+    if (/^https?:\/\//i.test(rawUrl)) return rawUrl;
+
+    return rawUrl.startsWith('/')
+      ? `${baseUrl}${rawUrl}`
+      : `${baseUrl}/${rawUrl}`;
+  };
+
+  const extractFilePathData = (rawUrl) => {
+    if (!rawUrl) return null;
+
+    const match = rawUrl.match(/\/data-sets\/([^/]+)\/files\/([^/?#]+)/i);
+    if (!match) return null;
+
+    let dataSetId;
+    let fileName;
+    try {
+      dataSetId = decodeURIComponent(match[1]);
+    } catch (err) {
+      console.warn('Decode failed for dataSetId:', match[1], err);
+      dataSetId = match[1];
+    }
+    try {
+      fileName = decodeURIComponent(match[2]);
+    } catch (err) {
+      console.warn('Decode failed for fileName:', match[2], err);
+      fileName = match[2];
+    }
+    return { dataSetId, fileName };
+  };
 
   document.querySelectorAll('.copy-link').forEach((button) => {
     button.addEventListener('click', async (event) => {
       try {
-        const link = event.target.value;
-
+        const link = event.currentTarget.value;
         await navigator.clipboard.writeText(link);
       } catch (err) {
         console.error('Clipboard write failed:', err);
@@ -13,44 +45,86 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const buttons = document.querySelectorAll('.download-resource');
-  buttons.forEach((button) => {
-    button.addEventListener('click', async function (event) {
+  document.querySelectorAll('.download-resource').forEach((button) => {
+    button.addEventListener('click', async (event) => {
       event.preventDefault();
 
-      const rawUrl = event.target.dataset.url;
-      const datasetId = event.target.dataset.id;
-      let url = `${baseUrl}/${rawUrl}`;
+      const target = event.currentTarget;
+      const rawUrl = (target.dataset.url || '').trim();
+      const fallbackDatasetId = (target.dataset.id || '').trim();
 
-      if (/^https?:\/\//i.test(rawUrl)) {
-        forceDownload(rawUrl);
+      let dataSetId = (target.dataset.datasetId || '').trim();
+      let fileName = (target.dataset.fileName || '').trim();
+
+      try {
+        fileName = decodeURIComponent(fileName);
+      } catch (err) {
+        console.warn('Decode failed:', fileName, err);
+      }
+
+      if ((!dataSetId || !fileName) && rawUrl) {
+        const parsed = extractFilePathData(rawUrl);
+        if (parsed) {
+          dataSetId = parsed.dataSetId;
+          fileName = parsed.fileName;
+        }
+      }
+
+      if (dataSetId && fileName) {
+        const downloadUrl = `${baseUrl}${appBasePath}/file-download?dataSetId=${encodeURIComponent(dataSetId)}&fileName=${encodeURIComponent(fileName)}`;
+
+        try {
+          const response = await fetch(downloadUrl);
+
+          if (response.ok) {
+            const data = await response.json();
+            window.location.href = data.url;
+            return;
+          }
+        } catch (err) {
+          console.error('Download URL fetch failed:', err);
+        }
+      }
+
+      if (rawUrl) {
+        const absoluteUrl = toAbsoluteUrl(rawUrl);
+
+        if (/^https?:\/\//i.test(rawUrl)) {
+          forceDownload(absoluteUrl);
+          return;
+        }
+
+        let canAccess = false;
+        try {
+          const res = await fetch(absoluteUrl, { method: 'HEAD' });
+          canAccess = res.ok;
+        } catch (err) {
+          console.warn('HEAD request failed for:', absoluteUrl, err);
+        }
+
+        if (canAccess) {
+          triggerDownload(absoluteUrl);
+        } else {
+          window.location.href = absoluteUrl;
+        }
+
         return;
       }
 
-      if (rawUrl.includes('/file-management-open/')) {
-        url = `${baseUrl}/${rawUrl}`;
-      }
-
-      try {
-        const res = await fetch(url, {
-          method: 'HEAD',
-        });
-
-        if (res.ok) {
-          const a = document.createElement('a');
-          a.href = url;
-          document.body.appendChild(a);
-          a.click();
-          a.remove();
-        } else {
-          window.location.href = `${baseUrl}/dataset/${datasetId}`;
-        }
-      } catch (err) {
-        console.error('Download check failed:', err);
-        window.location.href = `${baseUrl}/dataset/${datasetId}`;
+      if (fallbackDatasetId) {
+        window.location.href = `${baseUrl}/dataset/${fallbackDatasetId}`;
       }
     });
   });
+
+  function triggerDownload(url) {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = '';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
 
   function forceDownload(url, filename = '') {
     const a = document.createElement('a');
@@ -64,7 +138,5 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.removeChild(a);
   }
 
-  window.onload = function () {
-    window.scrollTo(0, 0);
-  };
+  window.addEventListener('load', () => window.scrollTo(0, 0));
 });

--- a/src/controllers/web/SearchResultsController.ts
+++ b/src/controllers/web/SearchResultsController.ts
@@ -7,8 +7,8 @@ import { environmentConfig } from '../../config/environmentConfig';
 import { Credentials } from '../../interfaces/auth';
 import { FormattedTabOptions } from '../../interfaces/detailsTab.interface';
 import { ISearchPayload } from '../../interfaces/queryBuilder.interface';
-import { ISearchItem, ISearchResults } from '../../interfaces/searchResponse.interface';
-import { getDocumentDetails, getSearchResults } from '../../services/handlers/searchApi';
+import { ISearchResults, Query } from '../../interfaces/searchResponse.interface';
+import { getDocumentDetails, getFileDownloadUrl, getSearchResults } from '../../services/handlers/searchApi';
 import {
   BASE_PATH,
   formIds,
@@ -190,7 +190,7 @@ const SearchResultsController = {
   renderSearchDetailsHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
     try {
       const docId = request.params.id;
-      const docDetails: ISearchItem = await getDocumentDetails(docId, request.auth.credentials as Credentials);
+      const docDetails = await getDocumentDetails(docId, request.auth.credentials as Credentials);
       const queryString: string = readQueryParams(request.query);
       const detailsTabOptions: FormattedTabOptions = await processDetailsTabData(docDetails);
 
@@ -233,6 +233,22 @@ const SearchResultsController = {
     };
     const queryString: string = upsertQueryParams(request.query, queryParamsObject, false);
     return response.redirect(`${BASE_PATH}${webRoutePaths.results}?${queryString}`);
+  },
+  getFileDownloadUrlHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
+    try {
+      const query = request.query as Query;
+      const dataSetId = query.dataSetId;
+      const fileName = query.fileName;
+      if (!dataSetId || !fileName) {
+        return response.response({ error: 'Missing dataSetId or fileName' }).code(400);
+      }
+      const result = await getFileDownloadUrl(dataSetId, fileName, request.auth.credentials as Credentials);
+      return response.response({ url: result.url }).code(200);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to get download URL';
+      console.error('[FileDownload] Error:', message);
+      return response.response({ error: message }).code(500);
+    }
   },
   filterStudyPeriodHandler: async (request: Request, response: ResponseToolkit): Promise<ResponseObject> => {
     const payload = request.payload as Record<string, string>;

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -16,15 +16,26 @@ export interface IBaseItem {
   dataSetReferenceLabel?: string;
 }
 
+export interface ITaxonomyKeyword {
+  sourceUri?: string;
+  sourceLabel?: string;
+  valueUri?: string;
+  valueLabel: string;
+}
+
 export interface IGeneralItem {
   alternateTitle?: string;
   topicCategories?: string[];
   language?: string;
   keywords?: string[];
+  taxonomyKeywords?: ITaxonomyKeyword[];
   abstract?: string;
   metadata?: IMetaData;
   temporalExtent?: ITemporalExtent;
   resources?: IResources[];
+  description?: string;
+  topics?: string[];
+  metadataLanguage?: string;
 }
 
 export interface IIdentifiers {
@@ -44,6 +55,14 @@ export interface ChildRecords extends IRelatedRecordBase {
   grandChildren?: ChildRecords[];
 }
 
+export interface IPublicContact {
+  organisationName?: string;
+  role?: string;
+  emailAddress?: string;
+  url?: string;
+  urlLabel?: string;
+}
+
 export interface IAccessItem {
   id: string;
   contacts?: Contact[];
@@ -52,8 +71,11 @@ export interface IAccessItem {
   resourceType?: string;
   resources?: IResources[] | undefined;
   contactEmail?: string;
+  publicContact?: IPublicContact;
   parentRecords?: ParentsRecords[];
   childRecords?: ChildRecords[];
+  metadataLanguage?: string;
+  entryType?: string;
 }
 
 export interface IAccess {
@@ -100,6 +122,8 @@ export interface ILicense {
 }
 
 export interface ILicenseItem {
+  text?: string;
+  url?: string;
   publicAccessAccessContraints?: string | undefined | null;
   publicAccessOtherConstraints?: string[];
   publicUseUseConstraints?: string | undefined | null;
@@ -107,6 +131,7 @@ export interface ILicenseItem {
   frequencyOfUpdate?: string;
   accrualPeriodicity?: string;
   attributionStatement?: string | undefined | null;
+  useLimitationStatement?: string | undefined | null;
 }
 
 export interface IGovernance {
@@ -132,7 +157,7 @@ export interface IRecordDates {
   metadata?: null | undefined | string;
 }
 
-interface IDataFormat {
+export interface IDataFormat {
   dataFormat: string;
 }
 
@@ -144,6 +169,11 @@ export interface IQualityItem {
   license?: ILicenseItem;
   resources?: IResources[] | undefined;
   dataFormats?: IDataFormat[] | undefined;
+  accrualPeriodicity?: string;
+  createdAt: number;
+  published: number;
+  modified: number;
+  metadataModified: number;
 }
 
 export interface IQuality {
@@ -236,8 +266,8 @@ export interface ISearchResults {
 }
 
 export interface ITemporalExtent {
-  beginPosition: string;
-  endPosition: string;
+  begin: string;
+  end: string;
 }
 export interface IGeometry {
   westBoundLongitude: number;
@@ -338,6 +368,8 @@ export interface IGeographyItem {
   spatial: SpatialItem;
   geospatialExtent?: IGeographyBoundry;
   geographicLocations?: string | undefined | null;
+  spatialRepresentationType: string;
+  coordinateReferenceSystemId?: string;
 }
 
 export interface INaturalItem {
@@ -351,7 +383,7 @@ export interface IMoreInfoSearchItem extends IGeographyItem, IQualityItem, IGene
   title?: string;
   resources: IResources[];
   temporalExtent: ITemporalExtent;
-  license: ILicenseItem;
+  licence: ILicenseItem;
   organisation?: string;
   nceaContribution: string;
 }

--- a/src/interfaces/searchResponse.interface.ts
+++ b/src/interfaces/searchResponse.interface.ts
@@ -259,6 +259,37 @@ export interface TabbedItem {
   tab?: string;
 }
 
+export type Query = {
+  dataSetId?: string;
+  fileName?: string;
+};
+
+export type HeadersMap = Record<string, string>;
+
+export type SearchDataWithOptionalFiles = IMoreInfoSearchItem & {
+  dataSet?: { id?: string };
+  files?: IResources[];
+};
+
+export type FileDownloadUrlResponse = {
+  url: string;
+};
+
+export type FileManagementFile = {
+  fileURI?: string;
+  name: string;
+  type: string;
+};
+
+export type CatalogServiceInstance = {
+  getCatalogueEntry: (docId: string, jwt: string | null) => Promise<object>;
+};
+
+export type FileManagementServiceInstance = {
+  listFilesOnDataSet: (dataSetId: string, jwt: string | null) => Promise<object>;
+  getFileDownloadUrl: (dataSetId: string, fileName: string, jwt: string | null) => Promise<object>;
+};
+
 export interface ISearchResults {
   total: number;
   items: ISearchItem[];

--- a/src/routes/web/searchResults.ts
+++ b/src/routes/web/searchResults.ts
@@ -28,6 +28,11 @@ const searchResultsRoutes = [
   },
   {
     method: 'GET',
+    path: '/file-download',
+    handler: SearchResultsController.getFileDownloadUrlHandler,
+  },
+  {
+    method: 'GET',
     path: webRoutePaths.getMapResults,
     handler: SearchResultsController.getMapResultsHandler,
   },

--- a/src/services/handlers/searchApi.ts
+++ b/src/services/handlers/searchApi.ts
@@ -5,7 +5,12 @@ import { environmentConfig } from '../../config/environmentConfig';
 import { Credentials } from '../../interfaces/auth';
 import { ISearchPayload } from '../../interfaces/queryBuilder.interface';
 import { IFilterFlags } from '../../interfaces/searchPayload.interface';
-import { IAggregationOptions, ISearchResponse, ISearchResults } from '../../interfaces/searchResponse.interface';
+import {
+  IAggregationOptions,
+  IMoreInfoSearchItem,
+  ISearchResponse,
+  ISearchResults,
+} from '../../interfaces/searchResponse.interface';
 import { getUrlAndAuthHeader } from '../../utils/authHeader';
 import { defaultFilterOptions } from '../../utils/constants';
 import { formatSearchResponse, transformSearchResponse } from '../../utils/formatSearchResponse';
@@ -183,26 +188,17 @@ const getDocumentDetails = async (docId: string, credentials: Credentials): Prom
 
     const catalogService = await getCatalogService();
 
-    const [agmApiSearchResponse, agmApiVocabalaryResponse] = await Promise.all([
-      fetch(`${url}/${docId}`, {
-        method: 'GET',
-        ...(Object.keys(searchHeaders).length ? { headers: searchHeaders } : {}),
-      }),
+    const [searchData, agmApiVocabalaryResponse] = await Promise.all([
+      catalogService.getCatalogueEntry(docId, credentials?.jwt ?? null) as Promise<IMoreInfoSearchItem>,
       fetch(`${vocabUrl}`, {
         method: 'GET',
         headers: vocabHeaders,
       }),
     ]);
-    const searchData1 = await catalogService.getCatalogueEntry(docId, credentials?.jwt ?? null);
-    console.log('searchData1', searchData1);
-    if (!agmApiSearchResponse.ok) {
-      throw new Error(`Error fetching results: ${agmApiSearchResponse.statusText}`);
-    }
 
     if (!agmApiVocabalaryResponse.ok) {
       throw new Error(`Error fetching vocabulary data: ${agmApiVocabalaryResponse.statusText}`);
     }
-    const searchData = await agmApiSearchResponse.json();
     const vocabularyData = await agmApiVocabalaryResponse.json();
     const finalResponse = formatSearchResponse(searchData, vocabularyData);
 

--- a/src/services/handlers/searchApi.ts
+++ b/src/services/handlers/searchApi.ts
@@ -51,8 +51,27 @@ const hasDataSetId = (
   return Object.prototype.toString.call(dataSetId) === '[object String]' && String(dataSetId).trim().length > 0;
 };
 
-const isObject = (value: object | null | undefined): value is object => {
+const isObject = (value: unknown): value is object => {
   return Object.prototype.toString.call(value) === '[object Object]';
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (Object.prototype.toString.call(error) === '[object String]' && String(error).trim().length > 0) {
+    return error as string;
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (isObject(error) && 'message' in error) {
+    const message = (error as { message?: string }).message;
+    if (Object.prototype.toString.call(message) === '[object String]' && String(message).trim().length > 0) {
+      return message as string;
+    }
+  }
+
+  return 'Unknown error';
 };
 
 const isMoreInfoSearchItem = (value: object): value is SearchDataWithOptionalFiles => {
@@ -197,7 +216,7 @@ const getSearchResults = async (
       return Promise.resolve({ total: 0, items: [], hasSpatialData: false });
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = getErrorMessage(error);
     throw new Error(`Error fetching results: ${message}`);
   }
 };
@@ -235,7 +254,7 @@ const getSearchResultsCount = async (parent: string, credentials: Credentials): 
     }
     return { totalResults: 0 };
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = getErrorMessage(error);
     throw new Error(`Error fetching category record count results: ${message}`);
   }
 };
@@ -266,7 +285,7 @@ const getFilterOptions = async (
       return Promise.resolve(fallbackResolve);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = getErrorMessage(error);
     throw new Error(`Error fetching results: ${message}`);
   }
 };
@@ -315,20 +334,28 @@ const getDocumentDetails = async (
 
     let formattedSearchData = searchDataResponse;
     if (fileDataSetId) {
-      const fileListResponse = await fileManagementService.listFilesOnDataSet(fileDataSetId, credentials?.jwt ?? null);
-      const files = getResourceFiles(fileListResponse);
-      if (files.length > 0) {
-        formattedSearchData = {
-          ...searchDataResponse,
-          files,
-        };
+      try {
+        const fileListResponse = await fileManagementService.listFilesOnDataSet(
+          fileDataSetId,
+          credentials?.jwt ?? null,
+        );
+        const files = getResourceFiles(fileListResponse);
+        if (files.length > 0) {
+          formattedSearchData = {
+            ...searchDataResponse,
+            files,
+          };
+        }
+      } catch {
+        // Some datasets may not exist in file management; return details without file links.
+        formattedSearchData = searchDataResponse;
       }
     }
     const finalResponse = formatSearchResponse(formattedSearchData, vocabularyData);
 
     return finalResponse;
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = getErrorMessage(error);
     throw new Error(`Error fetching results: ${message}`);
   }
 };

--- a/src/services/handlers/searchApi.ts
+++ b/src/services/handlers/searchApi.ts
@@ -6,10 +6,17 @@ import { Credentials } from '../../interfaces/auth';
 import { ISearchPayload } from '../../interfaces/queryBuilder.interface';
 import { IFilterFlags } from '../../interfaces/searchPayload.interface';
 import {
+  CatalogServiceInstance,
+  FileDownloadUrlResponse,
+  FileManagementFile,
+  FileManagementServiceInstance,
+  HeadersMap,
   IAggregationOptions,
-  IMoreInfoSearchItem,
+  IResources,
   ISearchResponse,
   ISearchResults,
+  NaturalCapitalTheme,
+  SearchDataWithOptionalFiles,
 } from '../../interfaces/searchResponse.interface';
 import { getUrlAndAuthHeader } from '../../utils/authHeader';
 import { defaultFilterOptions } from '../../utils/constants';
@@ -18,26 +25,126 @@ import { isEmpty } from '../../utils/isEmpty';
 import { generateSearchQuery } from '../../utils/queryBuilder';
 import { ISearchFiltersProcessed } from '../../utils/searchFilters';
 
-type HeadersMap = Record<string, string>;
-
-type CatalogServiceInstance = {
-  getCatalogueEntry: (docId: string, jwt: string | null) => Promise<unknown>;
-};
-
 let catalogServicePromise: Promise<CatalogServiceInstance> | null = null;
+
+let fileManagementServicePromise: Promise<FileManagementServiceInstance> | null = null;
 
 const getServicesConfigKey = (): ConfigEnv => {
   return environmentConfig.env === 'live' ? 'defraLive' : 'defraTest';
 };
 
+const isStringField = (value: object, key: string): boolean => {
+  return Object.prototype.toString.call(Reflect.get(value, key)) === '[object String]';
+};
+
+const isNullableStringField = (value: object, key: string): boolean => {
+  const fieldValue = Reflect.get(value, key);
+  return fieldValue === null || Object.prototype.toString.call(fieldValue) === '[object String]';
+};
+
+const hasDataSetId = (
+  searchData: SearchDataWithOptionalFiles,
+): searchData is SearchDataWithOptionalFiles & {
+  dataSet: { id: string };
+} => {
+  const dataSetId = searchData.dataSet?.id;
+  return Object.prototype.toString.call(dataSetId) === '[object String]' && String(dataSetId).trim().length > 0;
+};
+
+const isObject = (value: object | null | undefined): value is object => {
+  return Object.prototype.toString.call(value) === '[object Object]';
+};
+
+const isMoreInfoSearchItem = (value: object): value is SearchDataWithOptionalFiles => {
+  if (!('id' in value)) {
+    return false;
+  }
+
+  const id = Reflect.get(value, 'id');
+  return Object.prototype.toString.call(id) === '[object String]' && String(id).trim().length > 0;
+};
+
+const isResource = (value: object): value is IResources => {
+  if (!('url' in value) || !('type' in value) || !('name' in value) || !('language' in value)) {
+    return false;
+  }
+
+  const hasUrl = isStringField(value, 'url');
+  const hasType = isStringField(value, 'type');
+  const hasName = isStringField(value, 'name');
+  const hasLanguage = isNullableStringField(value, 'language');
+  return hasUrl && hasType && hasName && hasLanguage;
+};
+
+const isFileManagementFile = (value: object): value is FileManagementFile => {
+  if (!('name' in value) || !('type' in value)) {
+    return false;
+  }
+
+  const hasValidFileUri = !('fileURI' in value) || isStringField(value, 'fileURI');
+  return isStringField(value, 'name') && isStringField(value, 'type') && hasValidFileUri;
+};
+
+const getResourceFiles = (value: object): IResources[] => {
+  if (!('files' in value)) {
+    return [];
+  }
+
+  const filesCandidate = value.files;
+  if (!Array.isArray(filesCandidate)) {
+    return [];
+  }
+
+  return filesCandidate.flatMap((file): IResources[] => {
+    if (!isObject(file)) {
+      return [];
+    }
+
+    if (isResource(file)) {
+      return [file];
+    }
+
+    if (!isFileManagementFile(file)) {
+      return [];
+    }
+
+    return [
+      {
+        url: file.fileURI ?? '',
+        type: file.type,
+        name: file.name,
+        language: null,
+      },
+    ];
+  });
+};
+
+const hasValidFileDownloadUrl = (payload: { url?: string }): payload is FileDownloadUrlResponse => {
+  return Boolean(payload.url?.trim());
+};
+
+const isNaturalCapitalThemeArray = (payload: NaturalCapitalTheme[] | undefined): payload is NaturalCapitalTheme[] => {
+  return Array.isArray(payload);
+};
+
 const getCatalogService = async (): Promise<CatalogServiceInstance> => {
   if (!catalogServicePromise) {
     catalogServicePromise = import('@agrimetrics/services').then(({ CatalogService }) => {
-      return new CatalogService(getServicesConfigKey()) as CatalogServiceInstance;
+      return new CatalogService(getServicesConfigKey());
     });
   }
 
   return catalogServicePromise;
+};
+
+const getFileManagementService = async (): Promise<FileManagementServiceInstance> => {
+  if (!fileManagementServicePromise) {
+    fileManagementServicePromise = import('@agrimetrics/services').then(({ FileManagementService }) => {
+      return new FileManagementService(getServicesConfigKey());
+    });
+  }
+
+  return fileManagementServicePromise;
 };
 
 const requireUrl = (value: string | undefined, name: string): string => {
@@ -89,9 +196,9 @@ const getSearchResults = async (
     } else {
       return Promise.resolve({ total: 0, items: [], hasSpatialData: false });
     }
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-  } catch (error: any) {
-    throw new Error(`Error fetching results: ${error.message}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Error fetching results: ${message}`);
   }
 };
 
@@ -127,10 +234,9 @@ const getSearchResultsCount = async (parent: string, credentials: Credentials): 
       return { totalResults: categoryCountData?.totalDocumentCount ?? 0 };
     }
     return { totalResults: 0 };
-
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-  } catch (error: any) {
-    throw new Error(`Error fetching category record count results: ${error.message}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Error fetching category record count results: ${message}`);
   }
 };
 
@@ -141,7 +247,7 @@ const getFilterOptions = async (
   isQuickSearchJourney: boolean = false,
 ): Promise<IAggregationOptions> => {
   try {
-    const { isStudyPeriod = false } = filterFlags as IFilterFlags;
+    const isStudyPeriod = Boolean(filterFlags?.isStudyPeriod);
     if (Object.keys(searchFieldsObject.fields).length) {
       let finalResponse;
 
@@ -159,24 +265,17 @@ const getFilterOptions = async (
       }, {});
       return Promise.resolve(fallbackResolve);
     }
-  } catch (error: any) {
-    throw new Error(`Error fetching results: ${error.message}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Error fetching results: ${message}`);
   }
 };
 
-const getDocumentDetails = async (docId: string, credentials: Credentials): Promise<any> => {
+const getDocumentDetails = async (
+  docId: string,
+  credentials: Credentials,
+): Promise<ReturnType<typeof formatSearchResponse>> => {
   try {
-    const searchApiUrl = requireUrl(environmentConfig.searchApiUrl, 'SEARCH_API');
-    const { url, authHeader } = getUrlAndAuthHeader(searchApiUrl);
-
-    const searchHeaders: HeadersMap = {};
-
-    if (authHeader) {
-      searchHeaders.Authorization = authHeader;
-    } else if (credentials) {
-      searchHeaders.Authorization = `Bearer ${credentials.jwt}`;
-    }
-
     const vocabularyApiUrl = requireUrl(environmentConfig.vocabularyApiUrl, 'VOCABULARY_API');
     const { url: vocabUrl, authHeader: vocabAuthHeader } = getUrlAndAuthHeader(vocabularyApiUrl);
 
@@ -188,24 +287,82 @@ const getDocumentDetails = async (docId: string, credentials: Credentials): Prom
 
     const catalogService = await getCatalogService();
 
-    const [searchData, agmApiVocabalaryResponse] = await Promise.all([
-      catalogService.getCatalogueEntry(docId, credentials?.jwt ?? null) as Promise<IMoreInfoSearchItem>,
+    const fileManagementService = await getFileManagementService();
+
+    const [searchDataResponse, agmApiVocabalaryResponse] = await Promise.all([
+      catalogService.getCatalogueEntry(docId, credentials?.jwt ?? null),
       fetch(`${vocabUrl}`, {
         method: 'GET',
         headers: vocabHeaders,
       }),
     ]);
 
+    if (!isMoreInfoSearchItem(searchDataResponse)) {
+      throw new Error('Invalid catalogue response payload');
+    }
+
     if (!agmApiVocabalaryResponse.ok) {
       throw new Error(`Error fetching vocabulary data: ${agmApiVocabalaryResponse.statusText}`);
     }
-    const vocabularyData = await agmApiVocabalaryResponse.json();
-    const finalResponse = formatSearchResponse(searchData, vocabularyData);
+    const vocabularyDataRaw = await agmApiVocabalaryResponse.json();
+    const vocabularyData: NaturalCapitalTheme[] = isNaturalCapitalThemeArray(vocabularyDataRaw)
+      ? vocabularyDataRaw
+      : [];
+
+    const fileDataSetId = hasDataSetId(searchDataResponse)
+      ? searchDataResponse.dataSet.id.trim()
+      : searchDataResponse.id.trim();
+
+    let formattedSearchData = searchDataResponse;
+    if (fileDataSetId) {
+      const fileListResponse = await fileManagementService.listFilesOnDataSet(fileDataSetId, credentials?.jwt ?? null);
+      const files = getResourceFiles(fileListResponse);
+      if (files.length > 0) {
+        formattedSearchData = {
+          ...searchDataResponse,
+          files,
+        };
+      }
+    }
+    const finalResponse = formatSearchResponse(formattedSearchData, vocabularyData);
 
     return finalResponse;
-  } catch (error: any) {
-    throw new Error(`Error fetching results: ${error.message}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Error fetching results: ${message}`);
   }
 };
 
-export { getDocumentDetails, getFilterOptions, getSearchResultsCount, getSearchResults };
+const getFileDownloadUrl = async (
+  dataSetId: string,
+  fileName: string,
+  credentials: Credentials,
+): Promise<{ url: string }> => {
+  const searchApiUrl = requireUrl(environmentConfig.searchApiUrl, 'SEARCH_API');
+  const { url: baseUrl, authHeader } = getUrlAndAuthHeader(searchApiUrl);
+  const origin = new URL(baseUrl).origin;
+  const fileDownloadUrl = `${origin}/file-management-open/data-sets/${encodeURIComponent(dataSetId)}/files/${encodeURIComponent(fileName)}/download-url`;
+
+  const headers: HeadersMap = {};
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  } else if (credentials?.jwt) {
+    headers.Authorization = `Bearer ${credentials.jwt}`;
+  }
+
+  const response = await fetch(fileDownloadUrl, { method: 'GET', headers });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => String(response.status));
+    throw new Error(`Upstream /file-management-open returned ${response.status}: ${body}`);
+  }
+
+  const payload = await response.json();
+  if (!hasValidFileDownloadUrl(payload)) {
+    throw new Error('Upstream /file-management-open returned invalid payload');
+  }
+
+  return { url: payload.url };
+};
+
+export { getDocumentDetails, getFileDownloadUrl, getFilterOptions, getSearchResultsCount, getSearchResults };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -207,9 +207,9 @@ export const detailsTabOptions: TabOptions = {
   },
   license: {
     'Conditions for access and use -<br /> Use constraints': 'conditions_for_access_and_use_useConstraints',
-    'Limitations on public access -<br /> Access constraints': 'limitation_on_public_access',
-    'Limitations on public access -<br /> Other constraints': 'limitation_on_public_access_otherconstraint',
-    'Conditions for access and use -<br /> Other constraints': 'conditions_for_access_and_useOtherConstraints',
+    'Limitations on public access -<br /> Access constraints': 'limitation_on_public_access_otherconstraint',
+    'Limitations on public access -<br /> Other constraints': 'conditions_for_access_and_useOtherConstraints',
+    'Conditions for access and use -<br /> Other constraints': 'conditions_for_access_and_use_useConstraints',
     'Other Constraint': 'other_constraint',
     'Attribution statement': 'attribution_statement',
   },

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -113,4 +113,15 @@ const convertToDate = (day: string, month: string, year: string): Date | null =>
   }
 };
 
-export { formatDate, getYear, validateDate, convertToDate };
+const convertTimestampToIsoString = (timestamp: number | string): string => {
+  try {
+    const ms = typeof timestamp === 'string' ? parseInt(timestamp, 10) : timestamp;
+    if (isNaN(ms)) return '';
+    const isoString = new Date(ms).toISOString();
+    return formatDate(isoString, false, false);
+  } catch {
+    return '';
+  }
+};
+
+export { formatDate, getYear, validateDate, convertToDate, convertTimestampToIsoString };

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -114,14 +114,13 @@ const convertToDate = (day: string, month: string, year: string): Date | null =>
 };
 
 const convertTimestampToIsoString = (timestamp: number | string): string => {
-  try {
-    const ms = typeof timestamp === 'string' ? parseInt(timestamp, 10) : timestamp;
-    if (isNaN(ms)) return '';
-    const isoString = new Date(ms).toISOString();
-    return formatDate(isoString, false, false);
-  } catch {
+  const milliSeconds = Number(timestamp);
+  if (!Number.isFinite(milliSeconds)) {
     return '';
   }
+
+  const isoString = new Date(milliSeconds).toISOString();
+  return formatDate(isoString, false, false);
 };
 
 export { formatDate, getYear, validateDate, convertToDate, convertTimestampToIsoString };

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -85,8 +85,8 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
     };
   }
   const items = response.results.map((result: ISearchResult) => {
-    const startDate = toValidDate(result?.temporalExtent?.beginPosition);
-    const endDate = toValidDate(result?.temporalExtent?.endPosition);
+    const startDate = toValidDate(result?.temporalExtent?.begin);
+    const endDate = toValidDate(result?.temporalExtent?.end);
 
     const searchResponse = {
       id: result.id,
@@ -170,8 +170,8 @@ export const formatSearchResponse = (payload: IMoreInfoSearchItem, vocabularyDat
     id: payload?.id,
     title: payload?.title ?? '',
     publishedBy: payload?.organisation ?? '',
-    startYear: getYear(payload?.temporalExtent?.beginPosition ?? ''),
-    toYear: getYear(payload?.temporalExtent?.endPosition ?? ''),
+    startYear: getYear(payload?.temporalExtent?.begin ?? ''),
+    toYear: getYear(payload?.temporalExtent?.end ?? ''),
     // resourceLocator: resourceUrl,
     organisationName: payload?.organisation ?? '',
     ncea_group_reference: '',
@@ -180,7 +180,7 @@ export const formatSearchResponse = (payload: IMoreInfoSearchItem, vocabularyDat
     ...getGeneralTabData(payload),
     ...getAccessTabData(payload),
     ...getQualityTabData(payload),
-    ...getLicenseTabData(payload.license ?? {}),
+    ...getLicenseTabData(payload.licence ?? {}),
     ...getNaturalTab(payload, vocabularyData),
     ...getGovernanceTabData(payload.contacts ?? []),
     ...getGeographyTabData(payload),

--- a/src/utils/formatSearchResponse.ts
+++ b/src/utils/formatSearchResponse.ts
@@ -165,14 +165,14 @@ export const transformSearchResponse = (response: ISearchResponse, isMapResults:
 };
 
 export const formatSearchResponse = (payload: IMoreInfoSearchItem, vocabularyData: NaturalCapitalTheme[]) => {
-  // const resourceUrl = getResourceLocatorURL(payload?.resources[0]?.url ?? '');
+  const resourceLocator = payload?.resources?.[0]?.url ?? '';
   return {
     id: payload?.id,
     title: payload?.title ?? '',
     publishedBy: payload?.organisation ?? '',
     startYear: getYear(payload?.temporalExtent?.begin ?? ''),
     toYear: getYear(payload?.temporalExtent?.end ?? ''),
-    // resourceLocator: resourceUrl,
+    resourceLocator,
     organisationName: payload?.organisation ?? '',
     ncea_group_reference: '',
     project_number: '',

--- a/src/utils/getAccessTabData.ts
+++ b/src/utils/getAccessTabData.ts
@@ -1,10 +1,11 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 'use strict';
 
-import { DATA_DOWNLOADS_TYPES, DATA_SERVICES_TYPES } from './constants';
+import { DATA_DOWNLOADS_TYPES } from './constants';
 import { capitalizeWords } from './formatAggregationResponse';
 import { getOrganisationDetails } from './getOrganisationDetails';
 import { isEmpty } from './isEmpty';
+import { escapeHtmlAttribute } from './queryStringHelper';
 import { environmentConfig } from '../config/environmentConfig';
 import {
   Contact,
@@ -112,20 +113,29 @@ export const validateDataSetServiceTypes = (options: ServiceOptions, value: stri
   return lowerCaseServiceTypesSet.has(value.toLowerCase());
 };
 
-export const generateResourceWebsiteTable = (resources: IResources[], recordId: string) => {
-  if (Array.isArray(resources) && resources.length > 0) {
-    const filterDataServicesSet = resources.filter(({ type }) =>
-      validateDataSetServiceTypes(DATA_SERVICES_TYPES, type),
-    );
-    const filterDataDownloadSet = resources.filter(
-      ({ type }) => type !== null && validateServiceTypes(DATA_DOWNLOADS_TYPES, type),
-    );
-    const dataServicesTable = generateDataServicesTable(filterDataServicesSet, recordId);
-    const dataDownloadTable = generateDataDownloadsTable(filterDataDownloadSet, filterDataServicesSet, recordId);
+export const generateResourceWebsiteTable = (
+  filterDataServicesSet: IResources[],
+  recordId: string,
+  filterDataDownloadSet: IResources[] | { files?: IResources[] } = [],
+) => {
+  let dataServicesTable = '';
+  let dataDownloadTable = '';
 
-    return `${dataServicesTable}${dataDownloadTable}`;
+  if (Array.isArray(filterDataServicesSet) && filterDataServicesSet.length > 0) {
+    dataServicesTable = generateDataServicesTable(filterDataServicesSet, recordId);
   }
-  return '';
+
+  const files = Array.isArray(filterDataDownloadSet)
+    ? filterDataDownloadSet
+    : Array.isArray(filterDataDownloadSet?.files)
+      ? filterDataDownloadSet.files
+      : [];
+
+  if (files.length > 0) {
+    dataDownloadTable = generateDataDownloadsTable(files, filterDataServicesSet, recordId);
+  }
+
+  return `${dataServicesTable}${dataDownloadTable}`;
 };
 
 const generateDataServicesTable = (dataServices: IResources[], recordId: string) => {
@@ -201,11 +211,11 @@ export const extractFileFormat = (url: string | null) => {
 };
 
 export const createDownloadsTableRow = (payload, recordId) => {
-  const { distributionFormat, name, url, type } = payload;
+  const { distributionFormat, name, url, fileURI, type } = payload;
+  const fileUrl = url ?? fileURI ?? '';
   const dataSetName = isEmpty(name) ? 'N/A' : name;
-  const fileType = isEmpty(distributionFormat) ? extractFileFormat(url) : distributionFormat[0].toString();
-
-  if (isEmpty(url)) {
+  const fileType = isEmpty(distributionFormat) ? extractFileFormat(fileUrl) : distributionFormat[0].toString();
+  if (isEmpty(fileUrl)) {
     return `
    <tr>
     <td>${dataSetName}</td>
@@ -219,7 +229,13 @@ export const createDownloadsTableRow = (payload, recordId) => {
     <td>${dataSetName}</td>
     <td>${type === DATA_DOWNLOADS_TYPES.EIDC_DOCUMENT ? 'N/A' : fileType}</td>
     <td>
-      <button data-url="${url}" data-id="${recordId}" class="download-resource govuk-button copy-link-btn" type="button">Download</button>
+      <button
+        data-url="${escapeHtmlAttribute(fileUrl)}"
+        data-id="${escapeHtmlAttribute(recordId)}"
+        class="download-resource govuk-button copy-link-btn"
+        type="button">
+        Download
+      </button>      
     </td>
   </tr>
   `;
@@ -281,18 +297,23 @@ const createTableRow = (name: string, url: string, recordId: string) => {
   `;
 };
 
-const getAccessTabData = (payload: IAccessItem): IAccess => ({
-  ncea_catalogue_number: payload.id ?? '', // file identifier
-  host_catalogue_number: payload.id ?? '', // resource identifier
-  host_catalogue_entry: '',
-  resource_type_and_hierarchy: payload?.entryType ?? '',
-  // resource_locators: '', // keeps as empty as its value is not available from AGM side
-  contact_information: payload.publicContact?.emailAddress ?? '',
-  catalogue_number: '',
-  metadata_language: payload?.metadataLanguage?.toUpperCase() ?? '',
-  resourceWebsite: '',
-  parent_records: [],
-  child_records: [],
-});
+const getAccessTabData = (payload: IAccessItem): IAccess => {
+  const downloadFiles = (payload as { files?: IResources[] }).files ?? [];
+
+  return {
+    ncea_catalogue_number: payload.id ?? '', // file identifier
+    host_catalogue_number: payload.id ?? '', // resource identifier
+    host_catalogue_entry: '',
+    resource_type_and_hierarchy: payload?.entryType ?? '',
+    // resource_locators: '', // keeps as empty as its value is not available from AGM side
+    contact_information: payload.publicContact?.emailAddress ?? '',
+    catalogue_number: '',
+    // metadata_standard: payload?.metadata?.standard ?? '',
+    metadata_language: payload?.metadataLanguage?.toUpperCase() ?? '',
+    resourceWebsite: generateResourceWebsiteTable(payload.resources ?? [], payload.id, downloadFiles),
+    parent_records: [],
+    child_records: [],
+  };
+};
 
 export { getAccessTabData, getResourceLocators, getCoupledResource, getContactInformation, validateParentChildRecords };

--- a/src/utils/getAccessTabData.ts
+++ b/src/utils/getAccessTabData.ts
@@ -285,15 +285,14 @@ const getAccessTabData = (payload: IAccessItem): IAccess => ({
   ncea_catalogue_number: payload.id ?? '', // file identifier
   host_catalogue_number: payload.id ?? '', // resource identifier
   host_catalogue_entry: '',
-  resource_type_and_hierarchy: payload?.resourceType ?? '',
+  resource_type_and_hierarchy: payload?.entryType ?? '',
   // resource_locators: '', // keeps as empty as its value is not available from AGM side
-  contact_information: payload.contactEmail ?? '',
+  contact_information: payload.publicContact?.emailAddress ?? '',
   catalogue_number: '',
-  // metadata_standard: payload?.metadata?.standard ?? '',
-  metadata_language: payload?.metadata?.language?.toUpperCase() ?? '',
-  resourceWebsite: generateResourceWebsiteTable(payload.resources ?? [], payload.id),
-  parent_records: validateParentChildRecords(payload.parentRecords),
-  child_records: validateParentChildRecords(payload.childRecords),
+  metadata_language: payload?.metadataLanguage?.toUpperCase() ?? '',
+  resourceWebsite: '',
+  parent_records: [],
+  child_records: [],
 });
 
 export { getAccessTabData, getResourceLocators, getCoupledResource, getContactInformation, validateParentChildRecords };

--- a/src/utils/getGeneralTabData.ts
+++ b/src/utils/getGeneralTabData.ts
@@ -5,13 +5,13 @@ import remarkGfm from 'remark-gfm';
 import remarkHtml from 'remark-html';
 
 import { formatDate } from './dates';
-import { removeDuplicatesValues } from './queryStringHelper';
-import { IGeneralItem, ITemporalExtent } from '../interfaces/searchResponse.interface';
+import { getUniqueValues } from './queryStringHelper';
+import { IGeneralItem, ITaxonomyKeyword, ITemporalExtent } from '../interfaces/searchResponse.interface';
 
 export const getStudyPeriodDetails = (dateRanges: ITemporalExtent): string => {
-  const { beginPosition, endPosition } = dateRanges;
-  const startDate: string = beginPosition ? formatDate(beginPosition) : '';
-  const endDate: string = endPosition ? formatDate(endPosition) : '';
+  const { begin, end } = dateRanges;
+  const startDate: string = begin ? formatDate(begin) : '';
+  const endDate: string = end ? formatDate(end) : '';
 
   if (!startDate && !endDate) return '';
   if (!startDate) return `${endDate}`;
@@ -27,12 +27,20 @@ const formatContent = (content: string): string => {
   return String(result);
 };
 
+export const getKeywords = (keywords: ITaxonomyKeyword[]): string => {
+  const taxonomyKeywords = (keywords ?? []).map((item) => item.valueLabel || '').filter(Boolean);
+  if (taxonomyKeywords.length > 0) {
+    return getUniqueValues(taxonomyKeywords);
+  }
+  return '';
+};
+
 const getGeneralTabData = (payload: IGeneralItem) => ({
-  content: formatContent(payload?.abstract ?? ''),
+  content: formatContent(payload?.description ?? ''),
   studyPeriod: payload?.temporalExtent ? getStudyPeriodDetails(payload.temporalExtent) : '',
-  topicCategories: payload?.topicCategories?.join(', ') ?? '',
-  keywords: payload?.keywords ? removeDuplicatesValues(payload.keywords.join(', ').toLowerCase()) : '',
-  language: payload?.metadata?.language?.toLocaleUpperCase() ?? '',
+  topicCategories: getUniqueValues(payload?.topics ?? []),
+  keywords: getKeywords(payload?.taxonomyKeywords ?? []),
+  language: payload?.metadataLanguage?.toLocaleUpperCase() ?? '',
 });
 
 export { getGeneralTabData };

--- a/src/utils/getGeneralTabData.ts
+++ b/src/utils/getGeneralTabData.ts
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 import remarkHtml from 'remark-html';
 
 import { formatDate } from './dates';
-import { getUniqueValues } from './queryStringHelper';
+import { removeDuplicatesValues } from './queryStringHelper';
 import { IGeneralItem, ITaxonomyKeyword, ITemporalExtent } from '../interfaces/searchResponse.interface';
 
 export const getStudyPeriodDetails = (dateRanges: ITemporalExtent): string => {
@@ -30,7 +30,7 @@ const formatContent = (content: string): string => {
 export const getKeywords = (keywords: ITaxonomyKeyword[]): string => {
   const taxonomyKeywords = (keywords ?? []).map((item) => item.valueLabel || '').filter(Boolean);
   if (taxonomyKeywords.length > 0) {
-    return getUniqueValues(taxonomyKeywords);
+    return removeDuplicatesValues(taxonomyKeywords.join(','));
   }
   return '';
 };
@@ -38,7 +38,7 @@ export const getKeywords = (keywords: ITaxonomyKeyword[]): string => {
 const getGeneralTabData = (payload: IGeneralItem) => ({
   content: formatContent(payload?.description ?? ''),
   studyPeriod: payload?.temporalExtent ? getStudyPeriodDetails(payload.temporalExtent) : '',
-  topicCategories: getUniqueValues(payload?.topics ?? []),
+  topicCategories: removeDuplicatesValues(payload?.topics?.join(',') ?? ''),
   keywords: getKeywords(payload?.taxonomyKeywords ?? []),
   language: payload?.metadataLanguage?.toLocaleUpperCase() ?? '',
 });

--- a/src/utils/getGeographyTabData.ts
+++ b/src/utils/getGeographyTabData.ts
@@ -71,8 +71,8 @@ const getGeographyTabData = (payload: IGeographyItem): IGeography => {
 
   return {
     spatialDataService: payload?.spatial?.dataService ?? '',
-    spatialRepresentationService: payload?.spatial?.representationService ?? '',
-    spatialReferencingSystem: payload?.spatial?.referencingSystem ?? '',
+    spatialRepresentationService: payload?.spatialRepresentationType ?? '',
+    spatialReferencingSystem: payload?.coordinateReferenceSystemId ?? '',
     geographicLocations: '',
     geographicBoundary: coordinatesData?.coordinates ?? '',
     geographicBoundaryHtml: getGeographicBoundaryHtml(coordinatesData?.coordinates ?? ({} as IAccumulatedCoordinates)),

--- a/src/utils/getLicenseTabData.ts
+++ b/src/utils/getLicenseTabData.ts
@@ -10,14 +10,24 @@ const formmatLicenseData = (licenseData: string[]) => {
   return '';
 };
 
-const getLicenseTabData = (license: ILicenseItem): ILicense => {
+export const ConcateValues = (text: string, attributionStatement: string): string => {
+  if (text && attributionStatement) {
+    return `${text}<br>${attributionStatement}`;
+  }
+  return text || attributionStatement || '';
+};
+
+const getLicenseTabData = (licence: ILicenseItem): ILicense => {
   return {
-    limitation_on_public_access: license?.publicAccessAccessContraints ?? '',
-    limitation_on_public_access_otherconstraint: formmatLicenseData(license?.publicAccessOtherConstraints ?? []),
-    conditions_for_access_and_useOtherConstraints: license?.publicUseOtherContraints ?? '',
-    conditions_for_access_and_use_useConstraints: license?.publicUseUseConstraints ?? '',
+    limitation_on_public_access: licence?.useLimitationStatement ?? '',
+    limitation_on_public_access_otherconstraint: formmatLicenseData(licence?.publicAccessOtherConstraints ?? []),
+    conditions_for_access_and_useOtherConstraints: ConcateValues(
+      licence?.text ?? '',
+      licence?.attributionStatement ?? '',
+    ),
+    conditions_for_access_and_use_useConstraints: licence?.useLimitationStatement ?? '',
     other_constraint: '', // Need to test once data is availble from AGM side
-    attribution_statement: license?.attributionStatement ?? '',
+    attribution_statement: licence?.attributionStatement ?? '',
   };
 };
 export { getLicenseTabData, formmatLicenseData };

--- a/src/utils/getLicenseTabData.ts
+++ b/src/utils/getLicenseTabData.ts
@@ -10,18 +10,15 @@ const formmatLicenseData = (licenseData: string[]) => {
   return '';
 };
 
-export const ConcateValues = (text: string, attributionStatement: string): string => {
-  if (text && attributionStatement) {
-    return `${text}<br>${attributionStatement}`;
-  }
-  return text || attributionStatement || '';
+export const concateValues = (text: string, attributionStatement: string): string => {
+  return text && attributionStatement ? `${text}<br>${attributionStatement}` : text || attributionStatement || '';
 };
 
 const getLicenseTabData = (licence: ILicenseItem): ILicense => {
   return {
     limitation_on_public_access: licence?.useLimitationStatement ?? '',
     limitation_on_public_access_otherconstraint: formmatLicenseData(licence?.publicAccessOtherConstraints ?? []),
-    conditions_for_access_and_useOtherConstraints: ConcateValues(
+    conditions_for_access_and_useOtherConstraints: concateValues(
       licence?.text ?? '',
       licence?.attributionStatement ?? '',
     ),

--- a/src/utils/getQualityTabData.ts
+++ b/src/utils/getQualityTabData.ts
@@ -1,8 +1,9 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 'use strict';
 
-import { formatDate } from './dates';
-import { IQuality, IQualityItem } from '../interfaces/searchResponse.interface';
+import { convertTimestampToIsoString, formatDate } from './dates';
+import { getUniqueValues } from './queryStringHelper';
+import { IDataFormat, IQuality, IQualityItem } from '../interfaces/searchResponse.interface';
 
 const checkAtLeastOnePropertyValueExists = (sourceObject: Record<string, any>): boolean => {
   return sourceObject?.title || sourceObject?.pass || sourceObject?.explanation;
@@ -41,34 +42,22 @@ const getRecordsDates = (data: string): string => {
   return formatDate(data, false, false);
 };
 
-const getUniqueFormats = (formats: string[]): string => {
-  return [...new Set(formats)].join(', ');
-};
-
-export const getDistributionFormats = (resources, dataFormats): string => {
-  const resourceFormats = (resources ?? []).flatMap((item) => item.distributionFormat || []).filter(Boolean);
-
+export const getDistributionFormats = (dataFormats: IDataFormat[]): string => {
+  const resourceFormats = (dataFormats ?? []).map((item) => item?.dataFormat).filter(Boolean);
   if (resourceFormats.length > 0) {
-    return getUniqueFormats(resourceFormats);
+    return getUniqueValues(resourceFormats);
   }
-
-  const fallbackFormats = (dataFormats ?? []).map((item) => item?.dataFormat).filter(Boolean);
-
-  if (fallbackFormats.length > 0) {
-    return getUniqueFormats(fallbackFormats);
-  }
-
   return '';
 };
 
 const getQualityTabData = (payload: IQualityItem): IQuality => ({
-  publicationInformation: getRecordsDates(payload?.datasetReferenceDate?.publication ?? ''),
-  creationInformation: getRecordsDates(payload?.datasetReferenceDate?.creation ?? ''),
-  revisionInformation: getRecordsDates(payload?.datasetReferenceDate?.revision ?? ''),
-  metadataDate: getRecordsDates(payload?.datasetReferenceDate?.metadata ?? ''),
+  publicationInformation: convertTimestampToIsoString(payload?.published ?? ''),
+  creationInformation: convertTimestampToIsoString(payload?.createdAt ?? ''),
+  revisionInformation: convertTimestampToIsoString(payload?.modified ?? ''),
+  metadataDate: convertTimestampToIsoString(payload?.metadataModified ?? ''),
   lineage: payload?.lineage ?? '',
-  available_formats: getDistributionFormats(payload.resources ?? [], payload?.dataFormats ?? []),
-  frequency_of_update: payload?.license?.frequencyOfUpdate ?? payload?.license?.accrualPeriodicity,
+  available_formats: getDistributionFormats(payload?.dataFormats ?? []),
+  frequency_of_update: payload?.accrualPeriodicity ?? '',
   character_encoding: 'utf8',
 });
 

--- a/src/utils/getQualityTabData.ts
+++ b/src/utils/getQualityTabData.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 import { convertTimestampToIsoString, formatDate } from './dates';
-import { getUniqueValues } from './queryStringHelper';
+import { removeDuplicatesValues } from './queryStringHelper';
 import { IDataFormat, IQuality, IQualityItem } from '../interfaces/searchResponse.interface';
 
 const checkAtLeastOnePropertyValueExists = (sourceObject: Record<string, any>): boolean => {
@@ -45,7 +45,7 @@ const getRecordsDates = (data: string): string => {
 export const getDistributionFormats = (dataFormats: IDataFormat[]): string => {
   const resourceFormats = (dataFormats ?? []).map((item) => item?.dataFormat).filter(Boolean);
   if (resourceFormats.length > 0) {
-    return getUniqueValues(resourceFormats);
+    return removeDuplicatesValues(resourceFormats.join(','));
   }
   return '';
 };

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -235,6 +235,15 @@ const removeDuplicatesValues = (data: string) => {
   return '';
 };
 
+export const getUniqueValues = (keywords: string[]): string => {
+  const alreadyExist = new Map<string, string>();
+  keywords.forEach((k) => {
+    const lower = k.toLowerCase();
+    if (!alreadyExist.has(lower)) alreadyExist.set(lower, k);
+  });
+  return [...alreadyExist.values()].join(', ');
+};
+
 export {
   getQueryStringParams,
   upsertQueryParams,

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -235,15 +235,6 @@ const removeDuplicatesValues = (data: string) => {
   return '';
 };
 
-export const getUniqueValues = (keywords: string[]): string => {
-  const alreadyExist = new Map<string, string>();
-  keywords.forEach((k) => {
-    const lower = k.toLowerCase();
-    if (!alreadyExist.has(lower)) alreadyExist.set(lower, k);
-  });
-  return [...alreadyExist.values()].join(', ');
-};
-
 const escapeHtmlAttribute = (value: string): string => {
   return value
     .replace(/&/g, '&amp;')

--- a/src/utils/queryStringHelper.ts
+++ b/src/utils/queryStringHelper.ts
@@ -244,6 +244,15 @@ export const getUniqueValues = (keywords: string[]): string => {
   return [...alreadyExist.values()].join(', ');
 };
 
+const escapeHtmlAttribute = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+};
+
 export {
   getQueryStringParams,
   upsertQueryParams,
@@ -260,4 +269,5 @@ export {
   appendPublication,
   getClearFilterUrl,
   removeDuplicatesValues,
+  escapeHtmlAttribute,
 };


### PR DESCRIPTION
### What one thing this PR does?

Implemented a code change to replace the NCEA Backend GET endpoint with the DSP Catalogue Get a Single Dataset Catalog Entry endpoint. Updated existing functions and their corresponding test cases, and added new functions to align with the current response structure. The getCatalogueEntry method is now used to fetch DSP metadata by ID.

IssueID # NCEA-441

### Task details

https://dsp-support.atlassian.net/browse/NCEA-441

### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment/search/7b6c23f0-200e-453d-b3f9-1ace36974bce#general
