### PR TITLE
feat(analytics): Replace PostHog with MS Clarity for session replay

### DIFF
--- a/__tests__/config/environmentConfig.spec.ts
+++ b/__tests__/config/environmentConfig.spec.ts
@@ -94,7 +94,7 @@ describe('Environment environmentConfig', () => {
         surveyIndexPreviewRecordId: Joi.string(),
         featureFlag: Joi.boolean().valid(true, false).default(false),
         parentChildFeatureFlag: Joi.boolean().valid(true, false).default(false),
-        enablePostHogFeatureFlag: Joi.boolean().valid(true, false).default(false),
+        enableClarityFeatureFlag: Joi.boolean().valid(true, false).default(false),
         announcementFeatureFlag: Joi.boolean().valid(true, false).default(false),
         announcementStartDate: Joi.string().allow('').default(''),
         announcementEndDate: Joi.string().allow('').default(''),

--- a/__tests__/infrastructure/plugins/views.spec.ts
+++ b/__tests__/infrastructure/plugins/views.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/utils/constants';
 import nunjucks, { Environment } from 'nunjucks';
 import { customHapiViews } from '../../../src/infrastructure/plugins/views';
-import { getPostHogConfig } from '../../../src/utils/postHogConfig';
+import { getClarityConfig } from '../../../src/utils/clarityConfig';
 
 jest.mock('nunjucks');
 
@@ -93,7 +93,7 @@ describe('Vision Plugin Configuration', () => {
       isLocal: false,
       featureFlag: false,
       parentChildFeatureFlag: false,
-      enablePostHogFeatureFlag: false,
+      enableClarityFeatureFlag: false,
       headerNavigationLinks: [
         {
           text: 'Home',
@@ -112,7 +112,7 @@ describe('Vision Plugin Configuration', () => {
         },
       ],
       currentYear: new Date().getFullYear(),
-      ...getPostHogConfig(),
+      ...getClarityConfig(),
     });
     expect(mockEnvironment.addFilter).toHaveBeenCalledTimes(3);
   });

--- a/__tests__/routes/web/__snapshots__/404.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/404.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`404 Screen 404 > Sanpshot verification should match the 404 screen snap
 
 
     
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/accessibility.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
 
 
     
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -168,7 +168,7 @@ exports[`Accessibility Screen Accessibility > Sanpshot verification should match
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A42361%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A43457%2Fnatural-capital-ecosystem-assessment%2Faccessibility-statement' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/dateSearch.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`Guided Search - Date Questionnaire Screen Guided Search > Date Question
 
 
     
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/detailsPage.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Details route template Document details with data Check status code and
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -173,7 +173,7 @@ exports[`Details route template Document details with data Check status code and
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41097%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35439%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -1267,7 +1267,7 @@ exports[`Details route template Document details with partial data Check status 
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -1417,7 +1417,7 @@ exports[`Details route template Document details with partial data Check status 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44865%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A44023%2Fnatural-capital-ecosystem-assessment%2Fsearch%2F%257B1234-56789213123-1233-1234%257D' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/feeds.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Feeds Screen Feeds > Sanpshot verification should match the Feeds scree
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchGet.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Guided Search - Geography Questionnaire Screen GET Request Geography Qu
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/geographySearchPost.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -171,7 +171,7 @@ exports[`Guided Search - Geography Questionnaire Screen POST Request HTML elemen
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A34041%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A40175%2Fnatural-capital-ecosystem-assessment%2Fcoordinate-search' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/routes/web/__snapshots__/home.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/home.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Home Screen Home > Sanpshot verification should match the home screen s
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
+++ b/__tests__/routes/web/__snapshots__/resultsBlock.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Results block template Guided search journey Search results with empty 
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -172,7 +172,7 @@ exports[`Results block template Guided search journey Search results with empty 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A35869%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A39411%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -2157,7 +2157,7 @@ exports[`Results block template Guided search journey Search results with error 
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -2306,7 +2306,7 @@ exports[`Results block template Guided search journey Search results with error 
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A36329%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45983%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Ffdy%3D2000%26tdy%3D2023%26jry%3Dgs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -3099,7 +3099,7 @@ exports[`Results block template Quick search journey Search results with data sh
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -3248,7 +3248,7 @@ exports[`Results block template Quick search journey Search results with data sh
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A46775%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A38003%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -5457,7 +5457,7 @@ exports[`Results block template Quick search journey Search results with empty d
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -5606,7 +5606,7 @@ exports[`Results block template Quick search journey Search results with empty d
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A45573%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A33953%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">
@@ -7591,7 +7591,7 @@ exports[`Results block template Quick search journey Search results with error s
 
     
   
-  <link rel="stylesheet" href="/natural-capital-ecosystem-assessment/assets/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -7740,7 +7740,7 @@ exports[`Results block template Quick search journey Search results with error s
           <span class="text">Data Services Platform</span>
         </a>
        </span>
-        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41365%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
+        <div class="navLinks service-links"><span>Welcome, Guest&nbsp; <a href='/login?redirect_uri=http%3A%2F%2F127.0.0.1%3A41675%2Fnatural-capital-ecosystem-assessment%2Fsearch%3Fq%3Dmarine%26jry%3Dqs%26pg%3D1%26rpp%3D20%26srt%3Dmost_relevant%26rty%3Dall' class='govuk-link divider'>Login</a></span></div>
     </div>
 
     <div class="header__secondary">

--- a/__tests__/schema/environmentConfig.schema.spec.ts
+++ b/__tests__/schema/environmentConfig.schema.spec.ts
@@ -59,7 +59,7 @@ describe('Environment Configuration Schema', () => {
         surveyIndexPreviewRecordId: '123',
         featureFlag: true,
         parentChildFeatureFlag: true,
-        enablePostHogFeatureFlag: true,
+        enableClarityFeatureFlag: true,
         announcementFeatureFlag: true,
         announcementStartDate: '',
         announcementEndDate: '',

--- a/public/scripts/clarity.js
+++ b/public/scripts/clarity.js
@@ -1,0 +1,57 @@
+/**
+ * Microsoft Clarity Client-Side Session Replay
+ * Provides session recording and user behaviour analytics
+ */
+
+(function () {
+    'use strict';
+
+    const projectId = window.clarityProjectId;
+    const isEnabled = window.clarityEnabled !== false;
+
+    console.log('Initializing MS Clarity with project ID:', projectId, 'Enabled:', isEnabled);
+
+    if (!isEnabled || !projectId) {
+        console.log('MS Clarity is disabled or project ID not found');
+        return;
+    }
+
+    // Load Microsoft Clarity snippet
+    (function (c, l, a, r, i, t, y) {
+        c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
+        t = l.createElement(r);
+        t.async = 1;
+        t.src = 'https://www.clarity.ms/tag/' + i;
+        y = l.getElementsByTagName(r)[0];
+        y.parentNode.insertBefore(t, y);
+    })(window, document, 'clarity', 'script', projectId);
+
+    // Associate session with logged-in user email when available
+    if (typeof window.userEmail === 'string' && window.userEmail) {
+        clarity('identify', window.userEmail);
+        clarity('set', 'email', window.userEmail);
+    }
+
+    // Global API
+    window.Clarity = {
+        // Set a custom tag on the session
+        setTag: function (key, value) {
+            clarity('set', key, value);
+        },
+
+        // Identify the current user
+        identify: function (userId, properties) {
+            clarity('identify', userId, null, null, userId);
+            if (properties) {
+                Object.keys(properties).forEach(function (key) {
+                    clarity('set', key, properties[key]);
+                });
+            }
+        },
+
+        // Upgrade the session priority (e.g. on error)
+        upgrade: function (reason) {
+            clarity('upgrade', reason);
+        }
+    };
+})();

--- a/src/config/environmentConfig.ts
+++ b/src/config/environmentConfig.ts
@@ -31,7 +31,7 @@ const config: EnvironmentConfig = {
   surveyIndexPreviewRecordId: process.env.SURVEY_INDEX_PREVIEW_RECORD_ID,
   featureFlag: process.env.FEATURE_FLAG === 'true',
   parentChildFeatureFlag: process.env.PARENT_CHILD_FEATURE_FLAG === 'true',
-  enablePostHogFeatureFlag: process.env.ENABLE_POSTHOG === 'true',
+  enableClarityFeatureFlag: process.env.ENABLE_CLARITY === 'true',
   announcementFeatureFlag: process.env.ANNOUNCEMENT_FEATURE_FLAG === 'true',
   announcementStartDate: process.env.ANNOUNCEMENT_START_DATE,
   announcementEndDate: process.env.ANNOUNCEMENT_END_DATE,

--- a/src/infrastructure/plugins/views.ts
+++ b/src/infrastructure/plugins/views.ts
@@ -6,6 +6,7 @@ import nunjucks from 'nunjucks';
 import dateFilter from 'nunjucks-date-filter';
 
 import { environmentConfig } from '../../config/environmentConfig';
+import { getClarityConfig } from '../../utils/clarityConfig';
 import {
   BASE_PATH,
   accessibilityStatementUrl,
@@ -17,7 +18,6 @@ import {
   termsAndConditionsUrl,
   webRoutePaths,
 } from '../../utils/constants';
-import { getPostHogConfig } from '../../utils/postHogConfig';
 
 const packageJsonPath = path.join(process.cwd(), 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -114,8 +114,8 @@ const customHapiViews = {
       isLocal: environmentConfig.isLocal,
       featureFlag: environmentConfig.featureFlag,
       parentChildFeatureFlag: environmentConfig.parentChildFeatureFlag,
-      enablePostHogFeatureFlag: environmentConfig.enablePostHogFeatureFlag,
-      ...getPostHogConfig(),
+      enableClarityFeatureFlag: environmentConfig.enableClarityFeatureFlag,
+      ...getClarityConfig(),
     },
   },
 };

--- a/src/interfaces/environmentConfig.interface.ts
+++ b/src/interfaces/environmentConfig.interface.ts
@@ -17,7 +17,7 @@ export interface EnvironmentConfig {
   surveyIndexPreviewRecordId: string | undefined;
   featureFlag: boolean;
   parentChildFeatureFlag: boolean;
-  enablePostHogFeatureFlag: boolean;
+  enableClarityFeatureFlag: boolean;
   announcementFeatureFlag: boolean;
   announcementStartDate?: string | undefined;
   announcementEndDate?: string | undefined;

--- a/src/schema/environmentConfig.schema.ts
+++ b/src/schema/environmentConfig.schema.ts
@@ -69,9 +69,9 @@ export const environmentSchema: Joi.ObjectSchema = Joi.object({
     'boolean.base': 'Parent Child Feature Flag must be a boolean value',
     'any.only': 'Parent Child Flag is not valid',
   }),
-  enablePostHogFeatureFlag: Joi.boolean().valid(true, false).default(false).messages({
-    'boolean.base': 'Posthog Feature Flag must be a boolean value',
-    'any.only': 'Posthog Feature Flag is not valid',
+  enableClarityFeatureFlag: Joi.boolean().valid(true, false).default(false).messages({
+    'boolean.base': 'Clarity Feature Flag must be a boolean value',
+    'any.only': 'Clarity Feature Flag is not valid',
   }),
   announcementFeatureFlag: Joi.boolean().valid(true, false).default(false).messages({
     'boolean.base': 'Announcement Feature Flag must be a boolean value',

--- a/src/utils/clarityConfig.ts
+++ b/src/utils/clarityConfig.ts
@@ -1,0 +1,9 @@
+/**
+ * Microsoft Clarity Configuration Helper
+ * Add this to your view context to enable MS Clarity session replay
+ */
+
+export const getClarityConfig = () => ({
+  clarityEnabled: process.env.ENABLE_CLARITY !== 'false',
+  clarityProjectId: process.env.CLARITY_PROJECT_ID || '',
+});

--- a/src/views/layout/default.njk
+++ b/src/views/layout/default.njk
@@ -19,16 +19,15 @@
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ assetPath }}/css/application.css">
+  <link rel="stylesheet" href="https://environment.data.gov.uk/natural-capital-ecosystem-assessment/assets/css/application.css" crossorigin="anonymous">
   <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <meta name="version" content="v{{appVersion}}">
-  {% if enablePostHogFeatureFlag %}
+  {% if enableClarityFeatureFlag %}
     <script>
-      window.posthogEnabled = {{ posthogEnabled | default(false) }};
-      window.posthogApiKey = "{{ posthogApiKey | default('') }}";
-      window.posthogHost = "{{ posthogHost | default('https://eu.posthog.com') }}";
+      window.clarityEnabled = {{ clarityEnabled | default(false) }};
+      window.clarityProjectId = "{{ clarityProjectId | default('') }}";
       window.userEmail = {{ (user and user.email) | tojson | safe }};
     </script>
   {% endif %}
@@ -180,7 +179,7 @@
   </script>
   <script type="text/javascript" src="{{ assetPath }}/scripts/appinsights.js"></script>
   <script type="module" src="{{ assetPath }}/scripts/customScripts.js"></script>
-  {% if enablePostHogFeatureFlag %}
-    <script type="text/javascript" src="{{ assetPath }}/scripts/posthog.js"></script>
+  {% if enableClarityFeatureFlag %}
+    <script type="text/javascript" src="{{ assetPath }}/scripts/clarity.js"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
### What one thing this PR does?

- Remove PostHog client script and config utility (postHogConfig.ts)
- Add MS Clarity inline snippet in <head> of default.njk, gated by enableClarityFeatureFlag
- Add clarityConfig.ts utility reading ENABLE_CLARITY and CLARITY_PROJECT_ID env vars
- Update EnvironmentConfig interface, environmentConfig.ts, and Joi schema to use enableClarityFeatureFlag
- Update views.ts to import getClarityConfig and pass enableClarityFeatureFlag to view context
- Update stylesheet href to public CDN URL with crossorigin="anonymous" for Clarity CSS capture
- Update all affected unit tests to reference Clarity config instead of PostHog

### Task details

- [ NCEA-443 - Integrate MS Clarity for UX and user behavior analysis](https://dsp-support.atlassian.net/browse/NCEA-443)

### Dev-tested in

1. Local environment

- [Clarity Dashboard](https://clarity.microsoft.com/projects/view/wj6f02nf8r/dashboard?date=Last%203%20days)
