### PR TITLE
fix(pages): Updated links on category page

### DIFF
--- a/src/views/partials/categories_detail/trees_woodland.njk
+++ b/src/views/partials/categories_detail/trees_woodland.njk
@@ -21,7 +21,7 @@
       <h2 class="govuk-heading-m educational-copy-container__heading-m">NCEA trees and forestry products and data set</h2>
       <div class="grey-line">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-1 margin-top-10">
-          <a class="govuk-link data-categories__link" target="_blank" href="https://www.data.gov.uk/dataset/9461f463-c363-4309-ae77-fdcd7e9df7d3/ancient-woodland-england">Ancient Woodland Inventory</a>
+          <a class="govuk-link data-categories__link" href="/natural-capital-ecosystem-assessment/search/5d5d1352-7505-4906-b574-b666dcfb16b4">Ancient Woodland Inventory</a>
         </h3>
         <p class="govuk-body margin-bottom-10">
           The Ancient Woodland Inventory is a national geospatial data set mapping ancient woodland sites over 0.25 hectares, including ancient wood pasture and parkland. It identifies more than 52,000 sites across England and is currently being updated to expand and modernise this core evidence base on woodland extent and condition.
@@ -29,7 +29,7 @@
       </div>
       <div class="grey-line">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-1 margin-top-10">
-          <a class="govuk-link data-categories__link" target="_blank" href="https://environment.data.gov.uk/defra/97db9f06-94ed-49cf-bc72-333504ac62c1/details">National Forest Inventory Plus</a>
+          <a class="govuk-link data-categories__link" href="/natural-capital-ecosystem-assessment/search?org=Forestry+Commission&date-before=&date-after=&licence=&keywords=&scope=ncea&q=national+forest+inventory&jry=qs&pg=1&rpp=20&srt=most_relevant">National Forest Inventory Plus</a>
         </h3>
         <p class="govuk-body margin-bottom-10">
           An extension to the <a class="govuk-link data-categories__link" target="_blank" href="https://www.forestresearch.gov.uk/tools-and-resources/national-forest-inventory/">National Forest Inventory (NFI)</a>, The National Forest Inventory Plus consists of multiple projects that capture data on the ecological condition of woodlands.


### PR DESCRIPTION
### What one thing this PR does?

Updated the following two links on the Trees and Woodland category page:

- National Forest Inventory Plus

- Ancient Woodland Inventory

IssueID # NCEA-473


### Task details

https://dsp-support.atlassian.net/browse/NCEA-473

### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment/categoriesDetail/treeswoodland
