### PR TITLE
fix(pages): NCEA search download link not working

### DIFF
--- a/public/scripts/moreInfo.js
+++ b/public/scripts/moreInfo.js
@@ -20,15 +20,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const rawUrl = event.target.dataset.url;
       const datasetId = event.target.dataset.id;
-      let url = `${baseUrl}/${rawUrl}`;
-
+      const normalizedPath = rawUrl.startsWith('/') ? rawUrl : `/${rawUrl}`;
+      let url = `${baseUrl}${normalizedPath}`;
+      
       if (/^https?:\/\//i.test(rawUrl)) {
         forceDownload(rawUrl);
         return;
       }
 
       if (rawUrl.includes('/file-management-open/')) {
-        url = `${baseUrl}/${rawUrl}`;
+        url = `${baseUrl}${normalizedPath}`;
       }
 
       try {


### PR DESCRIPTION
### What one thing this PR does?

- Updated the code to remove the extra forward slash from the URL returned in the API response.

IssueID # NCEA-478

### Task details

https://dsp-support.atlassian.net/browse/NCEA-478

### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment/search/7b6c23f0-200e-453d-b3f9-1ace36974bce?q=peat&jry=qs&pg=1&rpp=20&srt=most_relevant#access
