### PR TITLE
fix(pages): Refactor landing page Search to Two-Column Grid

### DIFF
--- a/__tests__/routes/web/home.spec.ts
+++ b/__tests__/routes/web/home.spec.ts
@@ -95,7 +95,7 @@ describe('Home Screen', () => {
     describe('Search container content elements', () => {
       it('should render 3 child elements', async () => {
         const bannerContainer = document?.querySelector('.quick_search-container');
-        expect(bannerContainer?.childElementCount).toEqual(3);
+        expect(bannerContainer?.childElementCount).toEqual(4);
       });
 
       it('should render caption on home screen', async () => {
@@ -138,17 +138,17 @@ describe('Home Screen', () => {
 
     describe('Search container input field', () => {
       it('does render the input wrapper', () => {
-        const wrapper = document?.querySelector('.govuk-form-group > .govuk-input__wrapper');
+        const wrapper = document?.querySelector('.govuk-form-group');
         expect(wrapper).toBeTruthy();
       });
 
       it('should render the input element', async () => {
-        const inputElement = document?.querySelector('.govuk-form-group > .govuk-input__wrapper')?.firstElementChild;
+        const inputElement = document?.querySelector('.govuk-form-group > .search-block__input');
         expect(inputElement?.tagName.toLowerCase()).toBe('input');
       });
 
       it('should renders with custom class', () => {
-        const inputElement = document?.querySelector('.govuk-form-group > .govuk-input__wrapper')?.firstElementChild;
+        const inputElement = document?.querySelector('.govuk-form-group > .search-block__input');
         expect(inputElement?.classList.contains('search-block__input')).toBeTruthy();
       });
 
@@ -173,24 +173,20 @@ describe('Home Screen', () => {
       });
     });
 
-    describe('Search container when it includes a suffix', () => {
-      it('should renders the suffix inside the wrapper', () => {
+    describe('Search container submit button', () => {
+      it('should not render a suffix inside the input wrapper', () => {
         const suffix = document?.querySelector('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix');
-        expect(suffix).toBeTruthy();
+        expect(suffix).toBeFalsy();
       });
 
-      it('should renders a button in the suffix', () => {
-        const buttonElement = document?.querySelector(
-          '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix',
-        )?.firstElementChild;
+      it('should render a submit button below the input', () => {
+        const buttonElement = document?.querySelector('.search-block__form > .govuk-button');
         expect(buttonElement?.tagName?.toLowerCase()).toBe('button');
       });
 
-      it('should renders a button with custom class in the suffix', () => {
-        const buttonElement = document?.querySelector(
-          '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix',
-        )?.firstElementChild;
-        expect(buttonElement?.classList?.contains('search-block__button')).toBeTruthy();
+      it('should render the button with home search class', () => {
+        const buttonElement = document?.querySelector('.search-block__form > .govuk-button');
+        expect(buttonElement?.classList?.contains('home-search-button')).toBeTruthy();
       });
     });
   });
@@ -212,7 +208,9 @@ describe('Home Screen', () => {
 
   describe('Natural capital container block heading', () => {
     it('should render the Natural capital container heading', async () => {
-      expect(document?.querySelectorAll('.govuk-heading-m')?.[2]?.textContent?.trim()).toBe('Natural capital');
+      expect(document?.querySelector('.educational-copy-container__heading-m')?.textContent?.trim()).toBe(
+        'Natural capital',
+      );
     });
 
     it('should not render the custom large class for heading', async () => {

--- a/__tests__/routes/web/searchResults.spec.ts
+++ b/__tests__/routes/web/searchResults.spec.ts
@@ -173,7 +173,7 @@ describe('Results Screen', () => {
     describe('Search container content elements', () => {
       it('should render 3 child elements', async () => {
         const bannerContainer = document?.querySelector('.quick_search-container');
-        expect(bannerContainer?.childElementCount).toEqual(3);
+        expect(bannerContainer?.childElementCount).toEqual(4);
       });
 
       it('should render caption on home screen', async () => {
@@ -216,17 +216,17 @@ describe('Results Screen', () => {
 
     describe('Search container input field', () => {
       it('does render the input wrapper', () => {
-        const wrapper = document?.querySelector('.govuk-form-group > .govuk-input__wrapper');
+        const wrapper = document?.querySelector('.govuk-form-group');
         expect(wrapper).toBeTruthy();
       });
 
       it('should render the input element', async () => {
-        const inputElement = document?.querySelector('.govuk-form-group > .govuk-input__wrapper')?.firstElementChild;
+        const inputElement = document?.querySelector('.govuk-form-group > .search-block__input');
         expect(inputElement?.tagName.toLowerCase()).toBe('input');
       });
 
       it('should renders with custom class', () => {
-        const inputElement = document?.querySelector('.govuk-form-group > .govuk-input__wrapper')?.firstElementChild;
+        const inputElement = document?.querySelector('.govuk-form-group > .search-block__input');
         expect(inputElement?.classList.contains('search-block__input')).toBeTruthy();
       });
 
@@ -251,24 +251,20 @@ describe('Results Screen', () => {
       });
     });
 
-    describe('Search container when it includes a suffix', () => {
-      it('should renders the suffix inside the wrapper', () => {
+    describe('Search container submit button', () => {
+      it('should not render a suffix inside the input wrapper', () => {
         const suffix = document?.querySelector('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix');
-        expect(suffix).toBeTruthy();
+        expect(suffix).toBeFalsy();
       });
 
-      it('should renders a button in the suffix', () => {
-        const buttonElement = document?.querySelector(
-          '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix',
-        )?.firstElementChild;
+      it('should render a submit button below the input', () => {
+        const buttonElement = document?.querySelector('.search-block__form > .govuk-button');
         expect(buttonElement?.tagName?.toLowerCase()).toBe('button');
       });
 
-      it('should renders a button with custom class in the suffix', () => {
-        const buttonElement = document?.querySelector(
-          '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix',
-        )?.firstElementChild;
-        expect(buttonElement?.classList?.contains('search-block__button')).toBeTruthy();
+      it('should not use home-only button class on results page', () => {
+        const buttonElement = document?.querySelector('.search-block__form > .govuk-button');
+        expect(buttonElement?.classList?.contains('home-search-button')).toBeTruthy();
       });
     });
 
@@ -287,7 +283,9 @@ describe('Results Screen', () => {
 
     describe('Category search container block heading', () => {
       it('should render the Category search container heading', async () => {
-        expect(document?.querySelectorAll('.govuk-heading-m')?.[2]?.textContent?.trim()).toBe('Natural capital');
+        expect(document?.querySelector('.educational-copy-container__heading-m')?.textContent?.trim()).toBe(
+          'Natural capital',
+        );
       });
 
       it('should not render the custom large class for heading', async () => {

--- a/src/assets/sass/components/_search.scss
+++ b/src/assets/sass/components/_search.scss
@@ -8,24 +8,17 @@
       font-size: 36px;
     }
   }
-
-  &__caption-m {
-    @include font-style-stack(19px, 25px, 300);
-    color: $govuk-text-colour;
-    padding-top: 30px;
-  }
-
-  @media screen and (max-width: 799px) {
-    &__caption-m {
-      width: 100%;
-    }
-  }
 }
 
 .search-block {
+  .search-result-input-spacing {
+    margin-bottom: 25px;
+  }
+
   &__form {
     position: relative;
-    width: 630px;
+    width: 100%;
+    max-width: 630px;
     margin-bottom: 20px;
   }
 
@@ -49,23 +42,37 @@
     white-space: nowrap !important;
   }
 
-  &__button {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    border: 0;
-    background-color: $gov-defra-color-websafe;
-    color: govuk-colour('white');
-    cursor: pointer;
-    padding: 0;
-    width: 40px;
-    height: inherit;
-    background-image: govuk-image-url('search-icon.png');
-    background-repeat: no-repeat;
-    background-position: 10px 50%;
-    text-indent: -5000px;
-    overflow: hidden;
+}
+
+.home-search-divider {
+  border-color: #008938;
+  border-width: 2px;
+}
+
+.home-search-button,
+.home-guided-start-button {
+  font-size: 1.125rem;
+  line-height: 1;
+  font-weight: 400;
+  background-color: #008938;
+  box-shadow: 0 2px 0 #005a30;
+}
+
+@media (min-width: 40.0625em) {
+  .home-search-button,
+  .home-guided-start-button {
+    font-size: 1.5rem;
   }
+}
+
+.home-search-button:hover,
+.home-guided-start-button:hover {
+  background-color: #007a31;
+}
+
+.home-search-button[disabled]:hover,
+.home-guided-start-button[disabled]:hover {
+  background-color: #008938;
 }
 
 .data-container {

--- a/src/views/partials/quick_search/template.njk
+++ b/src/views/partials/quick_search/template.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full quick_search-container">
@@ -6,19 +7,17 @@
         Quick search
     </h1>
     {% if not params.isResultPage %}
-      <span class="govuk-caption-m quick_search-container__caption-m">You can search by keyword, theme, title or project code, for example: “peat”, “community supported fisheries”, “AE0101”.</span>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-4 home-search-divider">
+      <p class="govuk-body quick_search-container__caption-m govuk-!-margin-bottom-4">You can search by keyword, theme, title or project code, for example: “peat”, “community supported fisheries”, “AE0101”.</p>
     {% endif %}
     <div class="search-block" data-module="search">
-      <form action="{{params.searchPath}}" id="{{params.formId}}" data-do-browser-storage method="post" role="search" class="search-block__form govuk-!-margin-top-6">
+      <form action="{{params.searchPath}}" id="{{params.formId}}" data-do-browser-storage method="post" role="search" class="search-block__form">
         {{ govukInput({
           id: 'search_term',
           name: 'search_term',
           label: {
             text: 'Search',
             classes: 'search-block__label'
-          },
-          suffix: {
-            html: '<button type="submit" class="search-block__button" data-do-quick-search="true">Search</button>'
           },
           classes: 'govuk-input govuk-!-margin-bottom-0 search-block__input',
           spellcheck: false,
@@ -32,6 +31,13 @@
           errorMessage: params.searchInputError,
           formGroup: {
             classes: 'search-result-input-spacing'
+          }
+        }) }}
+        {{ govukButton({
+          text: 'Search',
+          classes: '' if params.isResultPage else 'home-search-button',
+          attributes: {
+            'data-do-quick-search': true
           }
         }) }}
         <input type="hidden" name="pageName" value="{% if not params.isResultPage %}home{% else %}results{% endif %}">

--- a/src/views/screens/home/template.njk
+++ b/src/views/screens/home/template.njk
@@ -20,45 +20,48 @@
     {% if announcementFeatureFlag %}
       {% include "partials/survey_banner/banner.njk" %}
     {% endif %}
-    {{ quickSearch({
-    searchPath: routes.searchResults,
-    formId: quickSearchFID,
-    isResultPage: false,
-    searchInputError : searchInputError
-  }) }}
-    <div class=" govuk-grid-column-full  govuk-grid-row ">
-      <h2 class="govuk-heading-m educational-copy-container__heading-m">
-        Natural capital
-      </h2>
-      <p class="govuk-body govuk-!-margin-bottom-6">
-        Natural capital includes certain stocks of the elements of nature that have value to society, such as forests, fisheries, rivers, biodiversity, land and minerals. Natural capital includes both the living and non-living aspects of ecosystems. Taking a natural capital approach is about considering the value of the natural environment for people and the economy.
-      </p>
+    
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        {{ quickSearch({
+        searchPath: routes.searchResults,
+        formId: quickSearchFID,
+        isResultPage: false,
+        searchInputError : searchInputError
+      }) }}
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+        Guided search
+        </h2>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-4 home-search-divider">
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          All resources in this service are classified into broad themes and specific categories relevant to taking a natural capital approach. Use the natural capital search to select the natural capital themes and categories of interest to help narrow down your search.
+        </p>
+        {{ govukButton({
+          id: 'guided-search',
+          name: 'guided-search',
+          text: "Start",
+          classes: 'home-guided-start-button',
+          isStartButton: true,
+          href: routes.guidedSearch+'?level=1',
+          attributes: {
+            'data-do-quick-search': false
+          }
+        }) }}
+      </div>
     </div>
-    <div class="govuk-grid-column-full  govuk-grid-row">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-6">
-        Natural Capital Search
-      </h2>
-      <p class="govuk-body govuk-!-margin-bottom-6">
-        All resources in this service are classified into broad themes and specific categories relevant to taking a natural capital approach. Use the natural capital search to select the natural capital themes and categories of interest to help narrow down your search.
-      </p>
-      {# disabling it enable once glossary link is available #}
-      {# <p class="govuk-body govuk-!-margin-bottom-6">
-        <a href="#" target="_blank" class='help-link'>Natural capital classification glossary</a>
-      </p> #}
-      <p class="govuk-body govuk-!-margin-bottom-6">
-       The Natural Capital Search is a beta service that is continuing to be improved. Your <a class='govuk-link' href="{{routes.feedbackLink}}" target="_blank">feedback</a> will help us improve it.
-      </p>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m educational-copy-container__heading-m">
+          Natural capital
+        </h2>
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          Natural capital includes certain stocks of the elements of nature that have value to society, such as forests, fisheries, rivers, biodiversity, land and minerals. Natural capital includes both the living and non-living aspects of ecosystems. Taking a natural capital approach is about considering the value of the natural environment for people and the economy.
+        </p>
+      </div>
     </div>
-    {{ govukButton({
-    id: 'guided-search',
-    name: 'guided-search',
-    text: "Start",
-    isStartButton: true,
-    href: routes.guidedSearch+'?level=1',
-    attributes: {
-      'data-do-quick-search': false
-    }
-  }) }}
+
   {% if featureFlag %}
     {% include "partials/home_data_categories/template.njk" %}
   {% endif %}


### PR DESCRIPTION
### What one thing this PR does?

- Changed the heading "Natural Capital Search" to "Guided Search". 
- Updated layout to display Quick Search and Guided Search in a two-column grid. 
- Updated Quick Search by replacing search icon button with a Search text button.

IssueID # NCEA-487

Refactor landing page Search to Two-Column Grid

### Task details

https://dsp-support.atlassian.net/browse/NCEA-487


### Dev-tested in

1. Local environment

http://localhost:4000/natural-capital-ecosystem-assessment
